### PR TITLE
Keep positions up-to-date

### DIFF
--- a/src/rewrite_clj/node.clj
+++ b/src/rewrite_clj/node.clj
@@ -35,7 +35,8 @@
    sexpr
    sexprs
    string
-   tag]
+   tag
+   trailer-length]
 
   [rewrite-clj.node.comment
    comment-node

--- a/src/rewrite_clj/node.clj
+++ b/src/rewrite_clj/node.clj
@@ -28,6 +28,7 @@
    child-sexprs
    concat-strings
    inner?
+   leader-length
    length
    printable-only?
    replace-children

--- a/src/rewrite_clj/node/fn.clj
+++ b/src/rewrite_clj/node/fn.clj
@@ -77,7 +77,7 @@
   (children [_]
     children)
   (replace-children [this children']
-    (assoc this :children children'))
+    (node/replace-children* this children'))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/fn.clj
+++ b/src/rewrite_clj/node/fn.clj
@@ -78,6 +78,8 @@
     children)
   (replace-children [this children']
     (node/replace-children* this children'))
+  (leader-length [_]
+    2)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/fn.clj
+++ b/src/rewrite_clj/node/fn.clj
@@ -80,6 +80,8 @@
     (node/replace-children* this children'))
   (leader-length [_]
     2)
+  (trailer-length [_]
+    1)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/forms.clj
+++ b/src/rewrite_clj/node/forms.clj
@@ -28,6 +28,8 @@
     (node/replace-children* this children'))
   (leader-length [_]
     0)
+  (trailer-length [_]
+    0)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/forms.clj
+++ b/src/rewrite_clj/node/forms.clj
@@ -26,6 +26,8 @@
     children)
   (replace-children [this children']
     (node/replace-children* this children'))
+  (leader-length [_]
+    0)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/forms.clj
+++ b/src/rewrite_clj/node/forms.clj
@@ -25,7 +25,7 @@
   (children [_]
     children)
   (replace-children [this children']
-    (assoc this :children children'))
+    (node/replace-children* this children'))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/meta.clj
+++ b/src/rewrite_clj/node/meta.clj
@@ -27,6 +27,8 @@
     (node/replace-children* this children'))
   (leader-length [_]
     (count prefix))
+  (trailer-length [_]
+    0)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/meta.clj
+++ b/src/rewrite_clj/node/meta.clj
@@ -25,6 +25,8 @@
   (replace-children [this children']
     (node/assert-sexpr-count children' 2)
     (node/replace-children* this children'))
+  (leader-length [_]
+    (count prefix))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/meta.clj
+++ b/src/rewrite_clj/node/meta.clj
@@ -24,7 +24,7 @@
   (children [_] children)
   (replace-children [this children']
     (node/assert-sexpr-count children' 2)
-    (assoc this :children children'))
+    (node/replace-children* this children'))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -114,7 +114,7 @@
   [nodes]
   (assert-sexpr-count nodes 1))
 
-(defn extent
+(defn ^:no-doc extent
   "A node's extent is how far it moves the \"cursor\".
 
   Rows are simple - if we have x newlines in the string representation, we

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -57,7 +57,9 @@
   (replace-children [_ children]
     "Replace the node's children.")
   (leader-length [_]
-    "How many characters appear before children?"))
+    "How many characters appear before children?")
+  (trailer-length [_]
+    "How many characters appear after children?"))
 
 (extend-protocol InnerNode
   Object
@@ -67,6 +69,8 @@
   (replace-children [_ _]
     (throw (UnsupportedOperationException.)))
   (leader-length [_]
+    (throw (UnsupportedOperationException.)))
+  (trailer-length [_]
     (throw (UnsupportedOperationException.))))
 
 (defn child-sexprs

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -114,7 +114,7 @@
   [nodes]
   (assert-sexpr-count nodes 1))
 
-(defn- extent
+(defn extent
   [node]
   (meta node))
 

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -171,7 +171,8 @@
                                             (let [[next-pos child'] (adjust-child pos child)]
                                               [next-pos (conj children child')]))
                                           [[row (+ col (leader-length node))] []]
-                                          children)]
+                                          children)
+        next-col (+ next-col (trailer-length node))]
    (-> node
      (assoc :children children')
      (with-meta {:row row

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -113,3 +113,7 @@
 (defn ^:no-doc assert-single-sexpr
   [nodes]
   (assert-sexpr-count nodes 1))
+
+(defn ^:no-doc replace-children*
+  [node children']
+  (assoc node :children children'))

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -115,35 +115,49 @@
   (assert-sexpr-count nodes 1))
 
 (defn extent
+  "A node's extent is how far it moves the \"cursor\".
+
+  Rows are simple - if we have x newlines in the string representation, we
+  will always move the \"cursor\" x rows.
+
+  Columns are strange.  If we have *any* newlines at all in the textual
+  representation of a node, following nodes' column positions are not
+  affected by our startting column position at all.  So the second number
+  in the pair we return is interpreted as a relative column adjustment
+  when the first number in the pair (rows) is zero, and as an absolute
+  column position when rows is non-zero."
   [node]
-  (meta node))
+  (let [{:keys [row col next-row next-col]} (meta node)]
+    (if (and row col next-row next-col)
+      [(- next-row row)
+       (if (= row next-row row)
+         (- next-col col)
+         next-col)]
+      (let [s (string node)
+            rows (->> s (filter (partial = \newline)) count)
+            cols (if (zero? rows)
+                   (count s)
+                   (->> s
+                     reverse
+                     (take-while (complement (partial = \newline)))
+                     count))]
+        [rows cols]))))
 
 (defn- adjust-child
   [[new-row new-col] node]
-  ;; TODO: Fix the case where we don't have existing metadata information
-  ;; for the node by computing the number of rows/cols.
-  
-  ;; TODO: Ensure new-row/new-col won't ever be nil and remove them from
-  ;; the check.
-
-  ;; TODO: Remove the `and` check entirely after handling all cases.
-  (let [{:keys [row col next-row next-col]} (extent node)]
-    (if (and new-row new-col row col next-row next-col)
-      (let [row-delta (- new-row row)
-            col-delta (if (= row next-row)
-                        (- new-col col)
-                        0)
-            next-row (+ next-row row-delta)
-            next-col (+ next-col col-delta)]
-        [[next-row next-col] (with-meta node {:row new-row
-                                              :col new-col
-                                              :next-row next-row
-                                              :next-col next-col})])
-    [[new-row new-col] node])))
+  (let [[rows cols] (extent node)
+        next-row (+ new-row rows)
+        next-col (if (zero? rows)
+                   (+ new-col cols)
+                   cols)]
+    [[next-row next-col] (with-meta node {:row new-row
+                                          :col new-col
+                                          :next-row next-row
+                                          :next-col next-col})]))
 
 (defn ^:no-doc replace-children*
   [node children]
-  (let [{:keys [row col]} (meta node)
+  (let [{:keys [row col] :or {row 1 col 1}} (meta node)
         [[next-row next-col] children'] (reduce
                                           (fn [[pos children] child]
                                             (let [[next-pos child'] (adjust-child pos child)]

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -114,6 +114,10 @@
   [nodes]
   (assert-sexpr-count nodes 1))
 
+(defn- extent
+  [node]
+  (meta node))
+
 (defn- adjust-child
   [[new-row new-col] node]
   ;; TODO: Fix the case where we don't have existing metadata information
@@ -123,13 +127,12 @@
   ;; the check.
 
   ;; TODO: Remove the `and` check entirely after handling all cases.
-
-  ;; TODO: Column handling is dependent on row handling; e.g. if the node
-  ;; spans more than one row, the column delta should not be applied.
-  (let [{:keys [row col next-row next-col]} (meta node)]
+  (let [{:keys [row col next-row next-col]} (extent node)]
     (if (and new-row new-col row col next-row next-col)
       (let [row-delta (- new-row row)
-            col-delta (- new-col col)
+            col-delta (if (= row next-row)
+                        (- new-col col)
+                        0)
             next-row (+ next-row row-delta)
             next-col (+ next-col col-delta)]
         [[next-row next-col] (with-meta node {:row new-row

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -55,7 +55,9 @@
   (children [_]
     "Get child nodes.")
   (replace-children [_ children]
-    "Replace the node's children."))
+    "Replace the node's children.")
+  (leader-length [_]
+    "How many characters appear before children?"))
 
 (extend-protocol InnerNode
   Object
@@ -63,6 +65,8 @@
   (children [_]
     (throw (UnsupportedOperationException.)))
   (replace-children [_ _]
+    (throw (UnsupportedOperationException.)))
+  (leader-length [_]
     (throw (UnsupportedOperationException.))))
 
 (defn child-sexprs

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -169,8 +169,8 @@
         [[next-row next-col] children'] (reduce
                                           (fn [[pos children] child]
                                             (let [[next-pos child'] (adjust-child pos child)]
-                                              [next-pos (conj children child)]))
-                                          [[row col] []]
+                                              [next-pos (conj children child')]))
+                                          [[row (+ col (leader-length node))] []]
                                           children)]
    (-> node
      (assoc :children children')

--- a/src/rewrite_clj/node/quote.clj
+++ b/src/rewrite_clj/node/quote.clj
@@ -20,6 +20,8 @@
   (replace-children [this children']
     (node/assert-single-sexpr children')
     (node/replace-children* this children'))
+  (leader-length [_]
+    (count prefix))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/quote.clj
+++ b/src/rewrite_clj/node/quote.clj
@@ -19,7 +19,7 @@
   (children [_] children)
   (replace-children [this children']
     (node/assert-single-sexpr children')
-    (assoc this :children children'))
+    (node/replace-children* this children'))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/quote.clj
+++ b/src/rewrite_clj/node/quote.clj
@@ -22,6 +22,8 @@
     (node/replace-children* this children'))
   (leader-length [_]
     (count prefix))
+  (trailer-length [_]
+    0)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/reader_macro.clj
+++ b/src/rewrite_clj/node/reader_macro.clj
@@ -33,6 +33,8 @@
     (node/replace-children* this children'))
   (leader-length [_]
     (inc (count prefix)))
+  (trailer-length [_]
+    (count suffix))
 
   Object
   (toString [this]
@@ -59,6 +61,8 @@
     (node/replace-children* this children'))
   (leader-length [_]
     1)
+  (trailer-length [_]
+    0)
 
   Object
   (toString [this]
@@ -85,6 +89,8 @@
     (node/replace-children* this children'))
   (leader-length [_]
     1)
+  (trailer-length [_]
+    0)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/reader_macro.clj
+++ b/src/rewrite_clj/node/reader_macro.clj
@@ -30,7 +30,7 @@
   (replace-children [this children']
     (when sexpr-count
       (node/assert-sexpr-count children' sexpr-count))
-    (assoc this :children children'))
+    (node/replace-children* this children'))
 
   Object
   (toString [this]
@@ -54,7 +54,7 @@
     children)
   (replace-children [this children']
     (node/assert-sexpr-count children' 2)
-    (assoc this :children children'))
+    (node/replace-children* this children'))
 
   Object
   (toString [this]
@@ -78,7 +78,7 @@
     children)
   (replace-children [this children']
     (node/assert-sexpr-count children' 1)
-    (assoc this :children children'))
+    (node/replace-children* this children'))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/reader_macro.clj
+++ b/src/rewrite_clj/node/reader_macro.clj
@@ -31,6 +31,8 @@
     (when sexpr-count
       (node/assert-sexpr-count children' sexpr-count))
     (node/replace-children* this children'))
+  (leader-length [_]
+    (inc (count prefix)))
 
   Object
   (toString [this]
@@ -55,6 +57,8 @@
   (replace-children [this children']
     (node/assert-sexpr-count children' 2)
     (node/replace-children* this children'))
+  (leader-length [_]
+    1)
 
   Object
   (toString [this]
@@ -79,6 +83,8 @@
   (replace-children [this children']
     (node/assert-sexpr-count children' 1)
     (node/replace-children* this children'))
+  (leader-length [_]
+    1)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/seq.clj
+++ b/src/rewrite_clj/node/seq.clj
@@ -27,6 +27,8 @@
     children)
   (replace-children [this children']
     (node/replace-children* this children'))
+  (leader-length [_]
+    (dec wrap-length))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/seq.clj
+++ b/src/rewrite_clj/node/seq.clj
@@ -29,6 +29,8 @@
     (node/replace-children* this children'))
   (leader-length [_]
     (dec wrap-length))
+  (trailer-length [_]
+    1)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/seq.clj
+++ b/src/rewrite_clj/node/seq.clj
@@ -26,7 +26,7 @@
   (children [_]
     children)
   (replace-children [this children']
-    (assoc this :children children'))
+    (node/replace-children* this children'))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/uneval.clj
+++ b/src/rewrite_clj/node/uneval.clj
@@ -20,6 +20,8 @@
   (replace-children [this children']
     (node/assert-single-sexpr children')
     (node/replace-children* this children'))
+  (leader-length [_]
+    2)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/uneval.clj
+++ b/src/rewrite_clj/node/uneval.clj
@@ -19,7 +19,7 @@
   (children [_] children)
   (replace-children [this children']
     (node/assert-single-sexpr children')
-    (assoc this :children children'))
+    (node/replace-children* this children'))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/uneval.clj
+++ b/src/rewrite_clj/node/uneval.clj
@@ -22,6 +22,8 @@
     (node/replace-children* this children'))
   (leader-length [_]
     2)
+  (trailer-length [_]
+    0)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/reader.clj
+++ b/src/rewrite_clj/reader.clj
@@ -120,7 +120,7 @@
   [reader read-fn]
   (let [start-position (position reader :row :col)]
     (if-let [entry (read-fn reader)]
-      (->> (position reader :end-row :end-col)
+      (->> (position reader :next-row :next-col)
            (merge start-position)
            (with-meta entry)))))
 

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -117,6 +117,25 @@
         (gen/vector (gen/choose 0 Long/MAX_VALUE) (+ max (inc max)))))))
 
 (defn node
+  "Generate parse nodes at random.
+  
+  `types` is a set of permissable top-level nodes.  If not specified, all
+  known top-level nodes are allowed.  This does not affect non-top-level
+  nodes.
+  
+  `depth` is the maximum depth of the tree.  It's possible the tree will be
+  shallower if we pick a lot of leaf-type nodes, but this is a limit.  If
+  not specified, the generator will pick depths from 1 through 5 at random.
+
+  Current implementation notes:
+
+   1. There's no attempt to nest things correctly.  For example, `#( ... )`
+      forms may be nested, and unquote operators may appear outside
+      syntax-quote forms.
+
+   2. Spaces and newlines are added at random, not in a smart way that
+      allows the tree to be converted to a string and reparsed.  Symbols
+      and constants will probably run together."
   ([]
    (node all-node-types))
   ([types]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -54,7 +54,6 @@
 
 ;; Container nodes
 
-;;eval-node
 ;;reader-macro-node
 ;;uneval-node
 ;;unquote-node
@@ -63,6 +62,7 @@
 (def ^:private containers
   [;ctor                     min max
    [#'node/deref-node        1   1]
+   [#'node/eval-node         1   1]
    [#'node/fn-node           1   5]
    [#'node/forms-node        0   5]
    [#'node/list-node         0   5]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -87,6 +87,3 @@
           (partial container* inner)
           containers)))
     atom-node))
-
-(def children
-  (gen/vector node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -68,7 +68,6 @@
 ;; Container nodes
 
 ;;fn-node
-;;list-node
 ;;map-node
 ;;meta-node
 ;;raw-meta-node
@@ -76,6 +75,10 @@
 (defn forms-node*
   [child-generator]
   (gen/fmap node/forms-node (gen/vector child-generator)))
+
+(defn list-node*
+  [child-generator]
+  (gen/fmap node/list-node (gen/vector child-generator)))
 
 (defn set-node*
   [child-generator]
@@ -88,6 +91,7 @@
 (defn container-node
   [inner-generator]
   (gen/one-of [(forms-node* inner-generator)
+               (list-node* inner-generator)
                (set-node* inner-generator)
                (vector-node* inner-generator)]))
 
@@ -98,5 +102,6 @@
   (gen/vector node))
 
 (def forms-node (forms-node* node))
+(def list-node (list-node* node))
 (def set-node (set-node* node))
 (def vector-node (vector-node* node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -57,13 +57,17 @@
     (comp node/newline-node (partial apply str))
     (gen/vector (gen/elements [\newline \return]) 1 5)))
 
-;;whitespace-node
+(def whitespace-node
+  (gen/fmap
+    (comp node/whitespace-node (partial apply str))
+    (gen/vector (gen/elements [\, \space \tab]) 1 5)))
 
 (def leaf-node
   (gen/one-of [comment-node
                integer-node
                keyword-node
-               newline-node]))
+               newline-node
+               whitespace-node]))
 
 (defn container-node
   [inner-generator]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -55,7 +55,6 @@
 ;; Container nodes
 
 ;;eval-node
-;;meta-node
 ;;raw-meta-node
 ;;reader-macro-node
 ;;uneval-node
@@ -69,6 +68,7 @@
    [#'node/forms-node        0   5]
    [#'node/list-node         0   5]
    [#'node/map-node          0   5]
+   [#'node/meta-node         2   2]
    [#'node/quote-node        1   1]
    [#'node/set-node          0   5]
    [#'node/syntax-quote-node 1   1]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -55,25 +55,25 @@
 ;; Container nodes
 
 ;;eval-node
-;;fn-node
 ;;meta-node
 ;;raw-meta-node
 ;;reader-macro-node
-;;syntax-quote-node
 ;;uneval-node
 ;;unquote-node
 ;;unquote-splicing-node
 
 (def ^:private containers
-  [;ctor               min max
-   [#'node/deref-node  1   1]
-   [#'node/forms-node  0   5]
-   [#'node/list-node   0   5]
-   [#'node/map-node    0   5]
-   [#'node/quote-node  1   1]
-   [#'node/set-node    0   5]
-   [#'node/var-node    1   1]
-   [#'node/vector-node 0   5]])
+  [;ctor                     min max
+   [#'node/deref-node        1   1]
+   [#'node/fn-node           1   5]
+   [#'node/forms-node        0   5]
+   [#'node/list-node         0   5]
+   [#'node/map-node          0   5]
+   [#'node/quote-node        1   1]
+   [#'node/set-node          0   5]
+   [#'node/syntax-quote-node 1   1]
+   [#'node/var-node          1   1]
+   [#'node/vector-node       0   5]])
 
 (defn- container*
   [child-generator [ctor min max]]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -30,16 +30,6 @@
       gen/keyword
       gen/boolean)))
 
-;;deref-node
-;;eval-node
-;;reader-macro-node
-;;var-node
-;;quote-node
-;;syntax-quote-node
-;;unquote-node
-;;unquote-splicing-node
-;;uneval-node
-
 (def newline-node
   (gen/fmap
     (comp node/newline-node (partial apply str))
@@ -67,9 +57,18 @@
 
 ;; Container nodes
 
+;;deref-node
+;;eval-node
 ;;fn-node
 ;;meta-node
+;;quote-node
 ;;raw-meta-node
+;;reader-macro-node
+;;syntax-quote-node
+;;uneval-node
+;;unquote-node
+;;unquote-splicing-node
+;;var-node
 
 (defn forms-node*
   [child-generator]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -76,8 +76,8 @@
 ;;vector-node
 
 (defn forms-node*
-  [children-generator]
-  (gen/fmap node/forms-node children-generator))
+  [child-generator]
+  (gen/fmap node/forms-node (gen/vector child-generator)))
 
 (defn container-node
   [inner-generator]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -72,11 +72,14 @@
 ;;map-node
 ;;meta-node
 ;;raw-meta-node
-;;set-node
 
 (defn forms-node*
   [child-generator]
   (gen/fmap node/forms-node (gen/vector child-generator)))
+
+(defn set-node*
+  [child-generator]
+  (gen/fmap node/set-node (gen/vector child-generator)))
 
 (defn vector-node*
   [child-generator]
@@ -85,6 +88,7 @@
 (defn container-node
   [inner-generator]
   (gen/one-of [(forms-node* inner-generator)
+               (set-node* inner-generator)
                (vector-node* inner-generator)]))
 
 (def node
@@ -94,4 +98,5 @@
   (gen/vector node))
 
 (def forms-node (forms-node* children))
+(def set-node (set-node* children))
 (def vector-node (vector-node* children))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -97,6 +97,6 @@
 (def children
   (gen/vector node))
 
-(def forms-node (forms-node* children))
-(def set-node (set-node* children))
-(def vector-node (vector-node* children))
+(def forms-node (forms-node* node))
+(def set-node (set-node* node))
+(def vector-node (vector-node* node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -38,7 +38,6 @@
 ;;syntax-quote-node
 ;;unquote-node
 ;;unquote-splicing-node
-;;token-node
 ;;uneval-node
 
 (def newline-node
@@ -48,6 +47,9 @@
 
 (def string-node
   (gen/fmap node/string-node gen/string-ascii))
+
+(def token-node
+  (gen/fmap node/token-node gen/symbol))
 
 (def whitespace-node
   (gen/fmap
@@ -60,6 +62,7 @@
                keyword-node
                newline-node
                string-node
+               token-node
                whitespace-node]))
 
 ;; Container nodes

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -26,7 +26,14 @@
       (gen/choose Long/MIN_VALUE Long/MAX_VALUE)
       (gen/choose 2 36))))
 
-;;keyword-node
+(def keyword-node
+  (gen/fmap
+    (fn [[kw namespaced?]]
+      (node/keyword-node kw namespaced?))
+    (gen/tuple
+      gen/keyword
+      gen/boolean)))
+
 ;;meta-node
 ;;raw-meta-node
 ;;deref-node
@@ -49,7 +56,8 @@
 
 (def leaf-node
   (gen/one-of [comment-node
-               integer-node]))
+               integer-node
+               keyword-node]))
 
 (defn container-node
   [inner-generator]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -56,7 +56,6 @@
 
 ;;reader-macro-node
 ;;uneval-node
-;;unquote-node
 
 (def ^:private containers
   [;ctor                         min max
@@ -71,6 +70,7 @@
    [#'node/raw-meta-node         2   2]
    [#'node/set-node              0   5]
    [#'node/syntax-quote-node     1   1]
+   [#'node/unquote-node          1   1]
    [#'node/unquote-splicing-node 1   1]
    [#'node/var-node              1   1]
    [#'node/vector-node           0   5]])

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -2,6 +2,8 @@
   (:require [clojure.test.check.generators :as gen]
             [rewrite-clj.node :as node]))
 
+;; Leaf nodes
+
 (def comment-node
   (gen/fmap
     (fn [[text eol]]
@@ -11,12 +13,6 @@
         #(re-matches #"[^\r\n]*" %)
         gen/string-ascii)
       (gen/elements ["" "\r" "\n"]))))
-
-;;fn-node
-
-(defn forms-node*
-  [children-generator]
-  (gen/fmap node/forms-node children-generator))
 
 (def integer-node
   (gen/fmap
@@ -34,17 +30,10 @@
       gen/keyword
       gen/boolean)))
 
-;;meta-node
-;;raw-meta-node
 ;;deref-node
 ;;eval-node
 ;;reader-macro-node
 ;;var-node
-;;list-node
-;;map-node
-;;set-node
-;;vector-node
-;;string-node
 ;;quote-node
 ;;syntax-quote-node
 ;;unquote-node
@@ -57,6 +46,9 @@
     (comp node/newline-node (partial apply str))
     (gen/vector (gen/elements [\newline \return]) 1 5)))
 
+(def string-node
+  (gen/fmap node/string-node gen/string-ascii))
+
 (def whitespace-node
   (gen/fmap
     (comp node/whitespace-node (partial apply str))
@@ -67,7 +59,22 @@
                integer-node
                keyword-node
                newline-node
+               string-node
                whitespace-node]))
+
+;; Container nodes
+
+;;fn-node
+;;list-node
+;;map-node
+;;meta-node
+;;raw-meta-node
+;;set-node
+;;vector-node
+
+(defn forms-node*
+  [children-generator]
+  (gen/fmap node/forms-node children-generator))
 
 (defn container-node
   [inner-generator]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -54,8 +54,7 @@
 
 ;; Container nodes
 
-;;reader-macro-node
-;;uneval-node
+;;uneval-node       (???)
 
 (def ^:private containers
   [;ctor                         min max
@@ -68,6 +67,7 @@
    [#'node/meta-node             2   2]
    [#'node/quote-node            1   1]
    [#'node/raw-meta-node         2   2]
+   [#'node/reader-macro-node     2   2]
    [#'node/set-node              0   5]
    [#'node/syntax-quote-node     1   1]
    [#'node/unquote-node          1   1]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -68,7 +68,6 @@
 ;; Container nodes
 
 ;;fn-node
-;;map-node
 ;;meta-node
 ;;raw-meta-node
 
@@ -79,6 +78,11 @@
 (defn list-node*
   [child-generator]
   (gen/fmap node/list-node (gen/vector child-generator)))
+
+;; TODO: Ensure an even number of non-whitespace nodes
+(defn map-node*
+  [child-generator]
+  (gen/fmap node/map-node (gen/vector child-generator)))
 
 (defn set-node*
   [child-generator]
@@ -92,6 +96,7 @@
   [inner-generator]
   (gen/one-of [(forms-node* inner-generator)
                (list-node* inner-generator)
+               (map-node* inner-generator)
                (set-node* inner-generator)
                (vector-node* inner-generator)]))
 
@@ -103,5 +108,6 @@
 
 (def forms-node (forms-node* node))
 (def list-node (list-node* node))
+(def map-node (map-node* node))
 (def set-node (set-node* node))
 (def vector-node (vector-node* node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -55,7 +55,6 @@
 ;; Container nodes
 
 ;;eval-node
-;;raw-meta-node
 ;;reader-macro-node
 ;;uneval-node
 ;;unquote-node
@@ -70,6 +69,7 @@
    [#'node/map-node          0   5]
    [#'node/meta-node         2   2]
    [#'node/quote-node        1   1]
+   [#'node/raw-meta-node     2   2]
    [#'node/set-node          0   5]
    [#'node/syntax-quote-node 1   1]
    [#'node/var-node          1   1]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -54,8 +54,6 @@
 
 ;; Container nodes
 
-;;uneval-node       (???)
-
 (def ^:private containers
   [;ctor                         min max
    [#'node/deref-node            1   1]
@@ -70,6 +68,7 @@
    [#'node/reader-macro-node     2   2]
    [#'node/set-node              0   5]
    [#'node/syntax-quote-node     1   1]
+   [#'node/uneval-node           1   1]
    [#'node/unquote-node          1   1]
    [#'node/unquote-splicing-node 1   1]
    [#'node/var-node              1   1]
@@ -77,7 +76,13 @@
 
 (defn- container*
   [child-generator [ctor min max]]
-  (gen/fmap ctor (gen/vector child-generator min max)))
+  (gen/fmap
+    ctor
+    (gen/vector (gen/such-that
+                  (complement node/printable-only?)
+                  child-generator)
+                min
+                max)))
 
 (def node
   (gen/recursive-gen 

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -57,23 +57,23 @@
 ;;reader-macro-node
 ;;uneval-node
 ;;unquote-node
-;;unquote-splicing-node
 
 (def ^:private containers
-  [;ctor                     min max
-   [#'node/deref-node        1   1]
-   [#'node/eval-node         1   1]
-   [#'node/fn-node           1   5]
-   [#'node/forms-node        0   5]
-   [#'node/list-node         0   5]
-   [#'node/map-node          0   5]
-   [#'node/meta-node         2   2]
-   [#'node/quote-node        1   1]
-   [#'node/raw-meta-node     2   2]
-   [#'node/set-node          0   5]
-   [#'node/syntax-quote-node 1   1]
-   [#'node/var-node          1   1]
-   [#'node/vector-node       0   5]])
+  [;ctor                         min max
+   [#'node/deref-node            1   1]
+   [#'node/eval-node             1   1]
+   [#'node/fn-node               1   5]
+   [#'node/forms-node            0   5]
+   [#'node/list-node             0   5]
+   [#'node/map-node              0   5]
+   [#'node/meta-node             2   2]
+   [#'node/quote-node            1   1]
+   [#'node/raw-meta-node         2   2]
+   [#'node/set-node              0   5]
+   [#'node/syntax-quote-node     1   1]
+   [#'node/unquote-splicing-node 1   1]
+   [#'node/var-node              1   1]
+   [#'node/vector-node           0   5]])
 
 (defn- container*
   [child-generator [ctor min max]]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -73,15 +73,19 @@
 ;;meta-node
 ;;raw-meta-node
 ;;set-node
-;;vector-node
 
 (defn forms-node*
   [child-generator]
   (gen/fmap node/forms-node (gen/vector child-generator)))
 
+(defn vector-node*
+  [child-generator]
+  (gen/fmap node/vector-node (gen/vector child-generator)))
+
 (defn container-node
   [inner-generator]
-  (gen/one-of [(forms-node* inner-generator)]))
+  (gen/one-of [(forms-node* inner-generator)
+               (vector-node* inner-generator)]))
 
 (def node
   (gen/recursive-gen container-node leaf-node))
@@ -89,5 +93,5 @@
 (def children
   (gen/vector node))
 
-(def forms-node
-  (forms-node* children))
+(def forms-node (forms-node* children))
+(def vector-node (vector-node* children))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -51,13 +51,19 @@
 ;;unquote-splicing-node
 ;;token-node
 ;;uneval-node
-;;newline-node
+
+(def newline-node
+  (gen/fmap
+    (comp node/newline-node (partial apply str))
+    (gen/vector (gen/elements [\newline \return]) 1 5)))
+
 ;;whitespace-node
 
 (def leaf-node
   (gen/one-of [comment-node
                integer-node
-               keyword-node]))
+               keyword-node
+               newline-node]))
 
 (defn container-node
   [inner-generator]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -74,6 +74,7 @@
    [#'node/map-node    0   5]
    [#'node/quote-node  1   1]
    [#'node/set-node    0   5]
+   [#'node/var-node    1   1]
    [#'node/vector-node 0   5]])
 
 (defn- container*

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -62,7 +62,7 @@
    ;containers        < > ctor
    :deref            [1 1 node/deref-node            ]
    :eval             [1 1 node/eval-node             ]
-   :fn               [1 5 node/fn-node               ]
+   :fn               [0 5 node/fn-node               ]
    :forms            [0 5 node/forms-node            ]
    :list             [0 5 node/list-node             ]
    :map              [0 5 node/map-node              ]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -78,6 +78,22 @@
    :var              [1 1 node/var-node              ]
    :vector           [0 5 node/vector-node           ]})
 
+
+(def all-node-types
+  (into #{} (keys node-specs)))
+
+(def leaf-node-types
+  (->> node-specs
+    (filter (comp gen/generator? second))
+    (map first)
+    (into #{})))
+
+(def printable-only-types
+  #{:comment
+    :newline
+    :whitespace
+    :uneval})
+
 (defn- container*
   [child-generator [min max ctor]]
   (gen/fmap
@@ -88,15 +104,6 @@
                   50)
                 min
                 max)))
-
-(def all-node-types
-  (into #{} (keys node-specs)))
-
-(def leaf-node-types
-  (->> node-specs
-    (filter (comp gen/generator? second))
-    (map first)
-    (into #{})))
 
 (defn node
   ([]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -54,21 +54,19 @@
 
 ;; Container nodes
 
-;;deref-node
 ;;eval-node
 ;;fn-node
 ;;meta-node
-;;quote-node
 ;;raw-meta-node
 ;;reader-macro-node
 ;;syntax-quote-node
 ;;uneval-node
 ;;unquote-node
 ;;unquote-splicing-node
-;;var-node
 
 (def ^:private containers
   [;ctor               min max
+   [#'node/deref-node  1   1]
    [#'node/forms-node  0   5]
    [#'node/list-node   0   5]
    [#'node/map-node    0   5]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -70,43 +70,27 @@
 ;;unquote-splicing-node
 ;;var-node
 
-(defn forms-node*
-  [child-generator]
-  (gen/fmap node/forms-node (gen/vector child-generator)))
+(def ^:private containers
+  [node/forms-node
+   node/list-node
+   node/map-node
+   node/set-node
+   node/vector-node])
 
-(defn list-node*
+(defn- container-node*
   [child-generator]
-  (gen/fmap node/list-node (gen/vector child-generator)))
+  (fn [ctor]
+    (gen/fmap ctor (gen/vector child-generator))))
 
-;; TODO: Ensure an even number of non-whitespace nodes
-(defn map-node*
-  [child-generator]
-  (gen/fmap node/map-node (gen/vector child-generator)))
-
-(defn set-node*
-  [child-generator]
-  (gen/fmap node/set-node (gen/vector child-generator)))
-
-(defn vector-node*
-  [child-generator]
-  (gen/fmap node/vector-node (gen/vector child-generator)))
-
-(defn container-node
+(defn- container-node
   [inner-generator]
-  (gen/one-of [(forms-node* inner-generator)
-               (list-node* inner-generator)
-               (map-node* inner-generator)
-               (set-node* inner-generator)
-               (vector-node* inner-generator)]))
+  (gen/one-of
+    (map
+      (container-node* inner-generator)
+      containers)))
 
 (def node
   (gen/recursive-gen container-node leaf-node))
 
 (def children
   (gen/vector node))
-
-(def forms-node (forms-node* node))
-(def list-node (list-node* node))
-(def map-node (map-node* node))
-(def set-node (set-node* node))
-(def vector-node (vector-node* node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -46,11 +46,14 @@
     (comp node/whitespace-node (partial apply str))
     (gen/vector (gen/elements [\, \space \tab]) 1 5)))
 
-(def atom-node
-  (gen/one-of [integer-node
+(def leaf-node
+  (gen/one-of [comment-node
+               integer-node
                keyword-node
+               newline-node
                string-node
-               token-node]))
+               token-node
+               whitespace-node]))
 
 ;; Container nodes
 
@@ -80,7 +83,8 @@
     ctor
     (gen/vector (gen/such-that
                   (complement node/printable-only?)
-                  child-generator)
+                  child-generator
+                  50)
                 min
                 max)))
 
@@ -91,4 +95,4 @@
         (map
           (partial container* inner)
           containers)))
-    atom-node))
+    leaf-node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -98,14 +98,23 @@
     :uneval})
 
 (defn- container*
+  "Helper to generate a container type.  Generates from `min` to `max` usable
+  nodes and from 0 to `(inc max)` printable-only nodes, then interleaves them
+  randomly.  The containers constructor, `ctor`, is then applied to the
+  resulting vector of children."
   [child-generator printable-only-generator [min max ctor]]
   (gen/fmap
     ctor
     (gen/fmap
-      first
+      (fn [[children printable-only ordering]]
+        (->> (concat children printable-only)
+          (map vector ordering)
+          (sort-by first)
+          (map second)))
       (gen/tuple
         (gen/vector child-generator min max)
-        (gen/vector printable-only-generator 0 (inc max))))))
+        (gen/vector printable-only-generator 0 (inc max))
+        (gen/vector (gen/choose 0 Long/MAX_VALUE) (+ max (inc max)))))))
 
 (defn node
   ([]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -2,6 +2,19 @@
   (:require [clojure.test.check.generators :as gen]
             [rewrite-clj.node :as node]))
 
+(def comment-node
+  (gen/fmap
+    (fn [[text eol]]
+      (node/comment-node (str text eol)))
+    (gen/tuple
+      (gen/such-that
+        #(re-matches #"[^\r\n]*" %)
+        gen/string-ascii)
+      (gen/elements ["" "\r" "\n"]))))
+
+;;fn-node
+;;forms-node
+
 (def integer-node
   (gen/fmap
     (fn [[n base]]
@@ -9,3 +22,30 @@
     (gen/tuple
       (gen/choose Long/MIN_VALUE Long/MAX_VALUE)
       (gen/choose 2 36))))
+
+;;keyword-node
+;;meta-node
+;;raw-meta-node
+;;deref-node
+;;eval-node
+;;reader-macro-node
+;;var-node
+;;list-node
+;;map-node
+;;set-node
+;;vector-node
+;;string-node
+;;quote-node
+;;syntax-quote-node
+;;unquote-node
+;;unquote-splicing-node
+;;token-node
+;;uneval-node
+;;newline-node
+;;whitespace-node
+
+(def node
+  (gen/one-of [comment-node]))
+
+(def children
+  (gen/vector node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -13,7 +13,10 @@
       (gen/elements ["" "\r" "\n"]))))
 
 ;;fn-node
-;;forms-node
+
+(defn forms-node*
+  [children-generator]
+  (gen/fmap node/forms-node children-generator))
 
 (def integer-node
   (gen/fmap
@@ -44,8 +47,19 @@
 ;;newline-node
 ;;whitespace-node
 
+(def leaf-node
+  (gen/one-of [comment-node
+               integer-node]))
+
+(defn container-node
+  [inner-generator]
+  (gen/one-of [(forms-node* inner-generator)]))
+
 (def node
-  (gen/one-of [comment-node]))
+  (gen/recursive-gen container-node leaf-node))
 
 (def children
   (gen/vector node))
+
+(def forms-node
+  (forms-node* children))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -28,6 +28,10 @@
                                        (fn [node]
                                          (gen/tuple
                                            (gen/return node)
-                                           (gen/vector g/node (count (node/children node))))))]
+                                           (gen/vector
+                                             (gen/such-that
+                                               (complement node/printable-only?)
+                                                g/node)
+                                             (count (remove node/printable-only? (node/children node)))))))]
         (= (count children)
            (count (node/children (node/replace-children node children))))))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -53,4 +53,15 @@
                                               (with-meta {:row row :col col})
                                               (node/replace-children children)
                                               meta)]
-        (= [row col] [after-row after-col])))))
+        (= [row col] [after-row after-col]))))
+
+  (property "adjacency: all replaced children are adjacent"
+    (prop/for-all [[node children] node-and-replacement-children]
+      (->> (node/children (node/replace-children node children))
+        (iterate rest)
+        (take-while #(>= (count %) 2))
+        (every?
+          (fn [[a b]]
+            (let [{:keys [next-row next-col]} (meta a)
+                  {:keys [row col]} (meta b)]
+              (= [next-row next-col] [row col]))))))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -52,3 +52,11 @@
             (let [{:keys [next-row next-col]} (meta a)
                   {:keys [row col]} (meta b)]
               (= [next-row next-col] [row col]))))))))
+
+(property "nodes with children report accurate leader lengths"
+  (prop/for-all [node (g/node g/container-node-types)]
+    (let [node-str (node/string node)
+          children-str (apply str (map node/string (node/children node)))
+          leader (node/leader-length node)]
+      (= (subs node-str leader (+ leader (count children-str)))
+         children-str))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -23,7 +23,11 @@
 (facts "about replacing children"
   (facts "replace-children preserves the meaning of the operation"
     (property "replace-children does not alter the number of children"
-      (prop/for-all [node (gen/such-that node/inner? g/node)
-                     children g/children]
+      (prop/for-all [[node children] (gen/bind
+                                       (gen/such-that node/inner? g/node)
+                                       (fn [node]
+                                         (gen/tuple
+                                           (gen/return node)
+                                           (gen/vector g/node (count (node/children node))))))]
         (= (count children)
            (count (node/children (node/replace-children node children))))))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -5,6 +5,7 @@
             [midje.sweet :refer :all]
             [rewrite-clj.node :as node]
             [rewrite-clj.node.generators :as g]
+            [rewrite-clj.node.protocols :refer [extent]]
             [rewrite-clj.test-helpers :refer :all]))
 
 (defn positions
@@ -37,4 +38,9 @@
     (property "post-replace-children children are equivalent to the requested ones" 50
       (prop/for-all [[node children] node-and-replacement-children]
         (= (map node/string children)
-           (map node/string (node/children (node/replace-children node children))))))))
+           (map node/string (node/children (node/replace-children node children)))))))
+
+  (property "replace-children does not affect the children's extents"
+    (prop/for-all [[node children] node-and-replacement-children]
+      (= (map extent children)
+         (map extent (node/children (node/replace-children node children)))))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -30,4 +30,13 @@
                                            (g/node #{type})
                                            (gen/fmap node/children (g/node #{type})))))]
         (= (count children)
-           (count (node/children (node/replace-children node children))))))))
+           (count (node/children (node/replace-children node children))))))
+    (property "post-replace-children children are equivalent to the requested ones" 50
+      (prop/for-all [[node children] (gen/bind
+                                       (gen/elements g/container-node-types)
+                                       (fn [type]
+                                         (gen/tuple
+                                           (g/node #{type})
+                                           (gen/fmap node/children (g/node #{type})))))]
+        (= (map node/string children)
+           (map node/string (node/children (node/replace-children node children))))))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -43,4 +43,14 @@
   (property "replace-children does not affect the children's extents"
     (prop/for-all [[node children] node-and-replacement-children]
       (= (map extent children)
-         (map extent (node/children (node/replace-children node children)))))))
+         (map extent (node/children (node/replace-children node children))))))
+
+  (property "replace-children does not move the parent's starting position"
+    (prop/for-all [[node children] node-and-replacement-children
+                   row (gen/choose 1 25)
+                   col (gen/choose 1 78)]
+      (let [{after-row :row after-col :col} (-> node
+                                              (with-meta {:row row :col col})
+                                              (node/replace-children children)
+                                              meta)]
+        (= [row col] [after-row after-col])))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -22,7 +22,7 @@
 
 (facts "about replacing children"
   (facts "replace-children preserves the meaning of the operation"
-    (property "replace-children does not alter the number of children"
+    (property "replace-children does not alter the number of children" 50
       (prop/for-all [[node children] (gen/bind
                                        (gen/such-that node/inner? g/node)
                                        (fn [node]

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -1,24 +1,11 @@
 (ns rewrite-clj.node.replace-children-test
-  (:require [clojure.test.check :as tc]
-            [clojure.test.check.generators :as gen]
+  (:require [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [midje.sweet :refer :all]
             [rewrite-clj.node :as node]
             [rewrite-clj.node.generators :as g]
             [rewrite-clj.node.protocols :refer [extent]]
             [rewrite-clj.test-helpers :refer :all]))
-
-(defn positions
-  [node]
-  (let [{:keys [row col next-row next-col]} (meta node)]
-    [row col next-row next-col]))
-
-(defn with-positions
-  [node [row col next-row next-col]]
-  (with-meta node {:row row
-                   :col col
-                   :next-row next-row
-                   :next-col next-col}))
 
 (def node-and-replacement-children
   (gen/bind

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -19,24 +19,22 @@
                    :next-row next-row
                    :next-col next-col}))
 
+(def node-and-replacement-children
+  (gen/bind
+    (gen/elements g/container-node-types)
+    (fn [type]
+      (gen/tuple
+        (g/node #{type})
+        (gen/fmap node/children (g/node #{type}))))))
 
 (facts "about replacing children"
+
   (facts "replace-children preserves the meaning of the operation"
     (property "replace-children does not alter the number of children" 50
-      (prop/for-all [[node children] (gen/bind
-                                       (gen/elements g/container-node-types)
-                                       (fn [type]
-                                         (gen/tuple
-                                           (g/node #{type})
-                                           (gen/fmap node/children (g/node #{type})))))]
+      (prop/for-all [[node children] node-and-replacement-children]
         (= (count children)
            (count (node/children (node/replace-children node children))))))
     (property "post-replace-children children are equivalent to the requested ones" 50
-      (prop/for-all [[node children] (gen/bind
-                                       (gen/elements g/container-node-types)
-                                       (fn [type]
-                                         (gen/tuple
-                                           (g/node #{type})
-                                           (gen/fmap node/children (g/node #{type})))))]
+      (prop/for-all [[node children] node-and-replacement-children]
         (= (map node/string children)
            (map node/string (node/children (node/replace-children node children))))))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -24,14 +24,14 @@
   (facts "replace-children preserves the meaning of the operation"
     (property "replace-children does not alter the number of children" 50
       (prop/for-all [[node children] (gen/bind
-                                       (gen/such-that node/inner? g/node)
+                                       (gen/such-that node/inner? (g/node))
                                        (fn [node]
                                          (gen/tuple
                                            (gen/return node)
                                            (gen/vector
                                              (gen/such-that
                                                (complement node/printable-only?)
-                                                g/node)
+                                                (g/node))
                                              (count (remove node/printable-only? (node/children node)))))))]
         (= (count children)
            (count (node/children (node/replace-children node children))))))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -1,5 +1,6 @@
 (ns rewrite-clj.node.replace-children-test
   (:require [clojure.test.check :as tc]
+            [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [midje.sweet :refer :all]
             [rewrite-clj.node :as node]
@@ -22,7 +23,7 @@
 (facts "about replacing children"
   (facts "replace-children preserves the meaning of the operation"
     (property "replace-children does not alter the number of children"
-      (prop/for-all [node g/node
+      (prop/for-all [node (gen/such-that node/inner? g/node)
                      children g/children]
         (= (count children)
            (count (node/children (node/replace-children node children))))))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -1,0 +1,26 @@
+(ns rewrite-clj.node.replace-children-test
+  (:require [midje.sweet :refer :all]
+            [rewrite-clj.node :refer :all]))
+
+(defn positions
+  [node]
+  (let [{:keys [row col next-row next-col]} (meta node)]
+    [row col next-row next-col]))
+
+(defn with-positions
+  [node [row col next-row next-col]]
+  (with-meta node {:row row
+                   :col col
+                   :next-row next-row
+                   :next-col next-col}))
+
+(tabular
+  (facts "replace-children fixes child positions"
+    (let [node (with-positions (?ctor []) ?pos)
+          children (map
+                     #(with-positions (token-node "foo") %)
+                     ?children)
+          node (replace-children node children)]
+      (positions node) => ?result))
+    ?ctor      ?pos      ?children   ?result
+    forms-node [1 1 1 5] [[1 1 1 3]] [1 1 1 3])

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -22,5 +22,6 @@
                      ?children)
           node (replace-children node children)]
       (positions node) => ?result))
-    ?ctor      ?pos      ?children   ?result
-    forms-node [1 1 1 5] [[1 1 1 3]] [1 1 1 3])
+    ?ctor      ?pos      ?children             ?result
+    forms-node [1 1 1 5] [[1 1 1 3]]           [1 1 1 3]
+    forms-node [1 1 1 5] [[1 1 1 3] [1 1 1 3]] [1 1 1 5])

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -42,6 +42,18 @@
                                               meta)]
         (= [row col] [after-row after-col]))))
 
+  (property "first replaced child starts after leader"
+    (prop/for-all [[node children] (gen/such-that
+                                     (fn [[node children]]
+                                       (not (zero? (count children))))
+                                     node-and-replacement-children)]
+      (let [updated-node (node/replace-children node children)
+            {:keys [row col]} (meta updated-node)
+            {child-row :row child-col :col} (meta (first (node/children updated-node)))]
+
+        (= [row (+ col (node/leader-length updated-node))]
+           [child-row child-col]))))
+
   (property "adjacency: all replaced children are adjacent"
     (prop/for-all [[node children] node-and-replacement-children]
       (->> (node/children (node/replace-children node children))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -60,3 +60,13 @@
           leader (node/leader-length node)]
       (= (subs node-str leader (+ leader (count children-str)))
          children-str))))
+
+(property "nodes with children report accurate trailer lengths"
+  (prop/for-all [node (g/node g/container-node-types)]
+    (let [node-str (node/string node)
+          children-str (apply str (map node/string (node/children node)))
+          trailer (node/trailer-length node)]
+      (= (subs node-str
+               (- (count node-str) (count children-str) trailer)
+               (- (count node-str) trailer))
+         children-str))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -54,6 +54,17 @@
         (= [row (+ col (node/leader-length updated-node))]
            [child-row child-col]))))
 
+  (property "last replaced child ends before trailer"
+    (prop/for-all [[node children] (gen/such-that
+                                     (fn [[node children]]
+                                       (not (zero? (count children))))
+                                     node-and-replacement-children)]
+      (let [updated-node (node/replace-children node children)
+            {:keys [next-row next-col]} (meta updated-node)
+            {child-next-row :next-row child-next-col :next-col} (meta (last (node/children updated-node)))]
+        (= [next-row next-col]
+           [child-next-row (+ child-next-col (node/trailer-length updated-node))]))))
+
   (property "adjacency: all replaced children are adjacent"
     (prop/for-all [[node children] node-and-replacement-children]
       (->> (node/children (node/replace-children node children))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -65,6 +65,13 @@
         (= [next-row next-col]
            [child-next-row (+ child-next-col (node/trailer-length updated-node))]))))
 
+  (property "removing all children sets width according to leader and trailer"
+    (prop/for-all [node (g/node #{:fn :forms :list :map :set :vector})]
+      (let [updated-node (node/replace-children node [])
+            {:keys [row col next-row next-col]} (meta updated-node)]
+        (= [next-row next-col]
+           [row (+ col (node/leader-length node) (node/trailer-length node))]))))
+
   (property "adjacency: all replaced children are adjacent"
     (prop/for-all [[node children] node-and-replacement-children]
       (->> (node/children (node/replace-children node children))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -24,14 +24,10 @@
   (facts "replace-children preserves the meaning of the operation"
     (property "replace-children does not alter the number of children" 50
       (prop/for-all [[node children] (gen/bind
-                                       (gen/such-that node/inner? (g/node))
-                                       (fn [node]
+                                       (gen/elements g/container-node-types)
+                                       (fn [type]
                                          (gen/tuple
-                                           (gen/return node)
-                                           (gen/vector
-                                             (gen/such-that
-                                               (complement node/printable-only?)
-                                                (g/node))
-                                             (count (remove node/printable-only? (node/children node)))))))]
+                                           (g/node #{type})
+                                           (gen/fmap node/children (g/node #{type})))))]
         (= (count children)
            (count (node/children (node/replace-children node children))))))))

--- a/test/rewrite_clj/node/replace_children_test.clj
+++ b/test/rewrite_clj/node/replace_children_test.clj
@@ -24,4 +24,5 @@
       (positions node) => ?result))
     ?ctor      ?pos      ?children             ?result
     forms-node [1 1 1 5] [[1 1 1 3]]           [1 1 1 3]
-    forms-node [1 1 1 5] [[1 1 1 3] [1 1 1 3]] [1 1 1 5])
+    forms-node [1 1 1 5] [[1 1 1 3] [1 1 1 3]] [1 1 1 5]
+    forms-node [1 1 1 5] [[1 3 2 4] [1 1 1 3]] [1 1 2 6])

--- a/test/rewrite_clj/parser_test.clj
+++ b/test/rewrite_clj/parser_test.clj
@@ -270,8 +270,8 @@
   "Create map associating row/column number pairs with the node at that position."
   [n]
   (let [start-pos ((juxt :row :col) (meta n))
-        end-pos ((juxt :end-row :end-col) (meta n))
-        entry {start-pos {:node n, :end-pos end-pos}}]
+        next-pos ((juxt :next-row :next-col) (meta n))
+        entry {start-pos {:node n, :next-pos next-pos}}]
     (if (node/inner? n)
       (->> (node/children n)
            (map nodes-with-meta)
@@ -283,19 +283,17 @@
                      (nodes-with-meta))]
   (tabular
     (fact "about row/column metadata."
-          (let [{:keys [node end-pos]} (positions ?pos)]
+          (let [{:keys [node next-pos]} (positions ?pos)]
             (node/tag node)    => ?t
             (node/string node) => ?s
             (node/sexpr node)  => ?sexpr
-            #_(fact
-                "reliable decision on end pos not currently possible."
-                end-pos => ?end)))
-    ?pos   ?end   ?t      ?s             ?sexpr
-    [1 1]  [3 14] :list   s              '(defn f [x] (println x))
-    [1 2]  [1 5]  :token  "defn"         'defn
+            next-pos           => ?next))
+    ?pos   ?next  ?t      ?s             ?sexpr
+    [1 1]  [3 15] :list   s              '(defn f [x] (println x))
+    [1 2]  [1 6]  :token  "defn"         'defn
     [1 7]  [1 8]  :token  "f"            'f
-    [2 3]  [2 5]  :vector "[x]"          '[x]
+    [2 3]  [2 6]  :vector "[x]"          '[x]
     [2 4]  [2 5]  :token  "x"            'x
-    [3 3]  [3 13] :list   "(println x)"  '(println x)
-    [3 4]  [3 10] :token  "println"      'println
+    [3 3]  [3 14] :list   "(println x)"  '(println x)
+    [3 4]  [3 11] :token  "println"      'println
     [3 12] [3 13] :token  "x"            'x))

--- a/test/rewrite_clj/parser_test.clj
+++ b/test/rewrite_clj/parser_test.clj
@@ -283,17 +283,24 @@
                      (nodes-with-meta))]
   (tabular
     (fact "about row/column metadata."
-          (let [{:keys [node next-pos]} (positions ?pos)]
+          (let [{:keys [node next-pos]} (positions ?pos)
+                node-sexpr (and ?sok (node/sexpr node))]
             (node/tag node)    => ?t
             (node/string node) => ?s
-            (node/sexpr node)  => ?sexpr
+            node-sexpr         => ?sexpr
             next-pos           => ?next))
-    ?pos   ?next  ?t      ?s             ?sexpr
-    [1 1]  [3 15] :list   s              '(defn f [x] (println x))
-    [1 2]  [1 6]  :token  "defn"         'defn
-    [1 7]  [1 8]  :token  "f"            'f
-    [2 3]  [2 6]  :vector "[x]"          '[x]
-    [2 4]  [2 5]  :token  "x"            'x
-    [3 3]  [3 14] :list   "(println x)"  '(println x)
-    [3 4]  [3 11] :token  "println"      'println
-    [3 12] [3 13] :token  "x"            'x))
+    ?pos   ?next  ?t          ?s             ?sok  ?sexpr
+    [1 1]  [3 15] :list       s              true  '(defn f [x] (println x))
+    [1 2]  [1 6]  :token      "defn"         true  'defn
+    [1 6]  [1 7]  :whitespace " "            false false
+    [1 7]  [1 8]  :token      "f"            true  'f
+    [1 8]  [2 1]  :newline    "\n"           false false
+    [2 1]  [2 3]  :whitespace "  "           false false
+    [2 3]  [2 6]  :vector     "[x]"          true  '[x]
+    [2 4]  [2 5]  :token      "x"            true  'x
+    [2 6]  [3 1]  :newline    "\n"           false false
+    [3 1]  [3 3]  :whitespace "  "           false false
+    [3 3]  [3 14] :list       "(println x)"  true  '(println x)
+    [3 4]  [3 11] :token      "println"      true  'println
+    [3 11] [3 12] :whitespace " "            false false
+    [3 12] [3 13] :token      "x"            true  'x))


### PR DESCRIPTION
**DO NOT MERGE YET**

There's a problem to resolve, but I decided to push the PR for review first.

**Overview:**

1. `end-row` and `end-col` have been renamed `next-row` and `next-col`, which makes them accurate.
2. `replace-children` was implemented so that it updates (and computes, if necessary) `row`, `col`, `next-row`, and `next-col` on all children and the parent.
3. The eight property tests are sufficient to verify the operation of `replace-children` is always correct.

**The Problem:**

The zipper defers replacing children in cases I didn't expect, so while we always *eventually* end up with the right row and column, we can have a stale position.  Yuck.

I'll investigate this soon.  The largest portion of work was the tricky test.check generators, which are still super valuable, so it's actually not a terrible deal if this approach won't work and we need to make a custom zipper.

**DO NOT MERGE YET**