### PR TITLE
Position in zipper

### DIFF
--- a/src/rewrite_clj/node.clj
+++ b/src/rewrite_clj/node.clj
@@ -28,6 +28,7 @@
    child-sexprs
    concat-strings
    inner?
+   leader-length
    length
    printable-only?
    replace-children

--- a/src/rewrite_clj/node/fn.clj
+++ b/src/rewrite_clj/node/fn.clj
@@ -78,6 +78,8 @@
     children)
   (replace-children [this children']
     (assoc this :children children'))
+  (leader-length [_]
+    2)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/forms.clj
+++ b/src/rewrite_clj/node/forms.clj
@@ -26,6 +26,8 @@
     children)
   (replace-children [this children']
     (assoc this :children children'))
+  (leader-length [_]
+    0)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/meta.clj
+++ b/src/rewrite_clj/node/meta.clj
@@ -25,6 +25,8 @@
   (replace-children [this children']
     (node/assert-sexpr-count children' 2)
     (assoc this :children children'))
+  (leader-length [_]
+    (count prefix))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -55,7 +55,9 @@
   (children [_]
     "Get child nodes.")
   (replace-children [_ children]
-    "Replace the node's children."))
+    "Replace the node's children.")
+  (leader-length [_]
+    "How many characters appear before children?"))
 
 (extend-protocol InnerNode
   Object
@@ -63,6 +65,8 @@
   (children [_]
     (throw (UnsupportedOperationException.)))
   (replace-children [_ _]
+    (throw (UnsupportedOperationException.)))
+  (leader-length [_]
     (throw (UnsupportedOperationException.))))
 
 (defn child-sexprs

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -117,3 +117,32 @@
 (defn ^:no-doc assert-single-sexpr
   [nodes]
   (assert-sexpr-count nodes 1))
+
+(defn ^:no-doc extent
+  "A node's extent is how far it moves the \"cursor\".
+
+  Rows are simple - if we have x newlines in the string representation, we
+  will always move the \"cursor\" x rows.
+
+  Columns are strange.  If we have *any* newlines at all in the textual
+  representation of a node, following nodes' column positions are not
+  affected by our startting column position at all.  So the second number
+  in the pair we return is interpreted as a relative column adjustment
+  when the first number in the pair (rows) is zero, and as an absolute
+  column position when rows is non-zero."
+  [node]
+  (let [{:keys [row col next-row next-col]} (meta node)]
+    (if (and row col next-row next-col)
+      [(- next-row row)
+       (if (= row next-row row)
+         (- next-col col)
+         next-col)]
+      (let [s (string node)
+            rows (->> s (filter (partial = \newline)) count)
+            cols (if (zero? rows)
+                   (count s)
+                   (->> s
+                     reverse
+                     (take-while (complement (partial = \newline)))
+                     count))]
+        [rows cols]))))

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -146,3 +146,8 @@
                      (take-while (complement (partial = \newline)))
                      count))]
         [rows cols]))))
+
+(defn ^:no-doc +extent
+  [[row col] [row-extent col-extent]]
+  [(+ row row-extent)
+   (cond-> col-extent (zero? row-extent) (+ col))])

--- a/src/rewrite_clj/node/protocols.clj
+++ b/src/rewrite_clj/node/protocols.clj
@@ -144,10 +144,12 @@
                    (->> s
                      reverse
                      (take-while (complement (partial = \newline)))
-                     count))]
+                     count
+                     inc))]
         [rows cols]))))
 
 (defn ^:no-doc +extent
   [[row col] [row-extent col-extent]]
   [(+ row row-extent)
    (cond-> col-extent (zero? row-extent) (+ col))])
+

--- a/src/rewrite_clj/node/quote.clj
+++ b/src/rewrite_clj/node/quote.clj
@@ -20,6 +20,8 @@
   (replace-children [this children']
     (node/assert-single-sexpr children')
     (assoc this :children children'))
+  (leader-length [_]
+    (count prefix))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/reader_macro.clj
+++ b/src/rewrite_clj/node/reader_macro.clj
@@ -31,6 +31,8 @@
     (when sexpr-count
       (node/assert-sexpr-count children' sexpr-count))
     (assoc this :children children'))
+  (leader-length [_]
+    (inc (count prefix)))
 
   Object
   (toString [this]
@@ -55,6 +57,8 @@
   (replace-children [this children']
     (node/assert-sexpr-count children' 2)
     (assoc this :children children'))
+  (leader-length [_]
+    1)
 
   Object
   (toString [this]
@@ -79,6 +83,8 @@
   (replace-children [this children']
     (node/assert-sexpr-count children' 1)
     (assoc this :children children'))
+  (leader-length [_]
+    1)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/seq.clj
+++ b/src/rewrite_clj/node/seq.clj
@@ -27,6 +27,8 @@
     children)
   (replace-children [this children']
     (assoc this :children children'))
+  (leader-length [_]
+    (dec wrap-length))
 
   Object
   (toString [this]

--- a/src/rewrite_clj/node/uneval.clj
+++ b/src/rewrite_clj/node/uneval.clj
@@ -20,6 +20,8 @@
   (replace-children [this children']
     (node/assert-single-sexpr children')
     (assoc this :children children'))
+  (leader-length [_]
+    2)
 
   Object
   (toString [this]

--- a/src/rewrite_clj/zip.clj
+++ b/src/rewrite_clj/zip.clj
@@ -23,7 +23,7 @@
 
 (import-vars
   [rewrite-clj.zip.zip
-   node root]
+   node position root]
 
   [rewrite-clj.zip.base
    child-sexprs

--- a/src/rewrite_clj/zip.clj
+++ b/src/rewrite_clj/zip.clj
@@ -17,12 +17,12 @@
              [parser :as p]
              [potemkin :refer [import-vars]]
              [node :as node]]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 ;; ## API Facade
 
 (import-vars
-  [clojure.zip
+  [rewrite-clj.zip.zip
    node root]
 
   [rewrite-clj.zip.base
@@ -92,17 +92,17 @@
                :arglists `(quote ~arglists)})]
     `(def ~sym ~base)))
 
-(defbase right* clojure.zip/right)
-(defbase left* clojure.zip/left)
-(defbase up* clojure.zip/up)
-(defbase down* clojure.zip/down)
-(defbase next* clojure.zip/next)
-(defbase prev* clojure.zip/prev)
-(defbase rightmost* clojure.zip/rightmost)
-(defbase leftmost* clojure.zip/leftmost)
-(defbase replace* clojure.zip/replace)
-(defbase edit* clojure.zip/edit)
-(defbase remove* clojure.zip/remove)
+(defbase right* rewrite-clj.zip.zip/right)
+(defbase left* rewrite-clj.zip.zip/left)
+(defbase up* rewrite-clj.zip.zip/up)
+(defbase down* rewrite-clj.zip.zip/down)
+(defbase next* rewrite-clj.zip.zip/next)
+(defbase prev* rewrite-clj.zip.zip/prev)
+(defbase rightmost* rewrite-clj.zip.zip/rightmost)
+(defbase leftmost* rewrite-clj.zip.zip/leftmost)
+(defbase replace* rewrite-clj.zip.zip/replace)
+(defbase edit* rewrite-clj.zip.zip/edit)
+(defbase remove* rewrite-clj.zip.zip/remove)
 
 ;; ## DEPRECATED
 

--- a/src/rewrite_clj/zip.clj
+++ b/src/rewrite_clj/zip.clj
@@ -103,6 +103,8 @@
 (defbase replace* rewrite-clj.zip.zip/replace)
 (defbase edit* rewrite-clj.zip.zip/edit)
 (defbase remove* rewrite-clj.zip.zip/remove)
+(defbase insert-left* rewrite-clj.zip.zip/insert-left)
+(defbase insert-right* rewrite-clj.zip.zip/insert-right)
 
 ;; ## DEPRECATED
 

--- a/src/rewrite_clj/zip/base.clj
+++ b/src/rewrite_clj/zip/base.clj
@@ -11,11 +11,7 @@
 (defn edn*
   "Create zipper over the given Clojure/EDN node."
   [node]
-  (z/zipper
-    node/inner?
-    (comp seq node/children)
-    node/replace-children
-    node))
+  (z/zipper node))
 
 (defn edn
   "Create zipper over the given Clojure/EDN node and move

--- a/src/rewrite_clj/zip/base.clj
+++ b/src/rewrite_clj/zip/base.clj
@@ -4,7 +4,7 @@
              [node :as node]
              [parser :as p]]
             [rewrite-clj.zip.whitespace :as ws]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 ;; ## Zipper
 

--- a/src/rewrite_clj/zip/edit.clj
+++ b/src/rewrite_clj/zip/edit.clj
@@ -7,7 +7,7 @@
              [utils :as u]
              [whitespace :as ws]]
             [rewrite-clj.node :as node]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 ;; ## In-Place Modification
 

--- a/src/rewrite_clj/zip/find.clj
+++ b/src/rewrite_clj/zip/find.clj
@@ -4,7 +4,7 @@
              [base :as base]
              [move :as m]]
             [rewrite-clj.node :as node]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 ;; ## Helpers
 

--- a/src/rewrite_clj/zip/insert.clj
+++ b/src/rewrite_clj/zip/insert.clj
@@ -3,7 +3,7 @@
              [base :as base]
              [whitespace :as ws]]
             [rewrite-clj.node :as node]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 (def ^:private space
   (node/spaces 1))

--- a/src/rewrite_clj/zip/move.clj
+++ b/src/rewrite_clj/zip/move.clj
@@ -1,7 +1,7 @@
 (ns ^:no-doc rewrite-clj.zip.move
   (:refer-clojure :exclude [next])
   (:require [rewrite-clj.zip.whitespace :as ws]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 (defn right
   "Move right to next non-whitespace/non-comment location."

--- a/src/rewrite_clj/zip/remove.clj
+++ b/src/rewrite_clj/zip/remove.clj
@@ -4,7 +4,7 @@
              [move :as m]
              [utils :as u]
              [whitespace :as ws]]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 (defn- remove-trailing-space
   "Remove all whitespace following a given node."

--- a/src/rewrite_clj/zip/seq.clj
+++ b/src/rewrite_clj/zip/seq.clj
@@ -6,7 +6,7 @@
              [find :as f]
              [insert :as i]
              [move :as m]]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 ;; ## Predicates
 

--- a/src/rewrite_clj/zip/subedit.clj
+++ b/src/rewrite_clj/zip/subedit.clj
@@ -1,6 +1,6 @@
 (ns ^:no-doc rewrite-clj.zip.subedit
   (:require [rewrite-clj.zip.base :as base]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 ;; ## Edit Scope
 

--- a/src/rewrite_clj/zip/utils.clj
+++ b/src/rewrite_clj/zip/utils.clj
@@ -4,24 +4,20 @@
 ;; ## Remove
 
 (defn- update-in-path
-  [{:keys [node path parent position] :as loc} k f]
-  (let [v (get path k)]
-    (if (seq v)
-      (assoc loc
-             :changed? true
-             :node node
-             :path (assoc path k (f v)))
-      loc)))
+  [{:keys [node path] :as loc} k f]
+  (if-let [v (get loc k)]
+    (assoc loc :changed? true k (f v))
+    loc))
 
 (defn remove-right
   "Remove right sibling of the current node (if there is one)."
   [loc]
-  (update-in-path loc :r next))
+  (update-in-path loc :right next))
 
 (defn remove-left
   "Remove left sibling of the current node (if there is one)."
   [loc]
-  (update-in-path loc :l pop))
+  (update-in-path loc :left pop))
 
 (defn remove-right-while
   "Remove elements to the right of the current zipper location as long as
@@ -50,19 +46,19 @@
 (defn remove-and-move-left
   "Remove current node and move left. If current node is at the leftmost
    location, returns `nil`."
-  [{:keys [position parent] {:keys [l] :as path} :path :as loc}]
-  (if (seq l)
+  [{:keys [position left] :as loc}]
+  (if (seq left)
     (assoc loc
            :changed? true
-           :node (peek l)
-           :path (update-in path [:l] pop))))
+           :node (peek left)
+           :left (pop left))))
 
 (defn remove-and-move-right
   "Remove current node and move right. If current node is at the rightmost
    location, returns `nil`."
-  [{:keys [position parent] {:keys [r] :as path} :path :as loc}]
-  (if (seq r)
+  [{:keys [position right] :as loc}]
+  (if (seq right)
     (assoc loc
            :changed? true
-           :node (first r)
-           :path (update-in path [:r] next))))
+           :node (first right)
+           :right (next right))))

--- a/src/rewrite_clj/zip/utils.clj
+++ b/src/rewrite_clj/zip/utils.clj
@@ -1,5 +1,5 @@
 (ns ^:no-doc rewrite-clj.zip.utils
-  (:require [clojure.zip :as z]))
+  (:require [rewrite-clj.zip.zip :as z]))
 
 ;; ## Remove
 

--- a/src/rewrite_clj/zip/utils.clj
+++ b/src/rewrite_clj/zip/utils.clj
@@ -48,10 +48,12 @@
    location, returns `nil`."
   [{:keys [position left] :as loc}]
   (if (seq left)
-    (assoc loc
-           :changed? true
-           :node (peek left)
-           :left (pop left))))
+    (let [[lnode lpos] (peek left)]
+      (assoc loc
+             :changed? true
+             :node lnode
+             :position lpos
+             :left (pop left)))))
 
 (defn remove-and-move-right
   "Remove current node and move right. If current node is at the rightmost

--- a/src/rewrite_clj/zip/utils.clj
+++ b/src/rewrite_clj/zip/utils.clj
@@ -4,7 +4,7 @@
 ;; ## Remove
 
 (defn- update-in-path
-  [{:keys [node path] :as loc} k f]
+  [loc k f]
   (if-let [v (get loc k)]
     (assoc loc :changed? true k (f v))
     loc))
@@ -16,8 +16,13 @@
 
 (defn remove-left
   "Remove left sibling of the current node (if there is one)."
-  [loc]
-  (update-in-path loc :left pop))
+  [{:keys [left] :as loc}]
+  (if-let [[_ lpos] (peek left)]
+    (assoc loc
+           :left (pop left)
+           :position lpos
+           :changed? true)
+    loc))
 
 (defn remove-right-while
   "Remove elements to the right of the current zipper location as long as

--- a/src/rewrite_clj/zip/utils.clj
+++ b/src/rewrite_clj/zip/utils.clj
@@ -4,12 +4,12 @@
 ;; ## Remove
 
 (defn- update-in-path
-  [[node path :as loc] k f]
+  [{:keys [node path position] :as loc} k f]
   (let [v (get path k)]
     (if (seq v)
-      (with-meta
-        [node (assoc path k (f v) :changed? true) (loc 2)]
-        (meta loc))
+      {:node node
+       :path (assoc path k (f v) :changed? true)
+       :position position}
       loc)))
 
 (defn remove-right
@@ -49,25 +49,21 @@
 (defn remove-and-move-left
   "Remove current node and move left. If current node is at the leftmost
    location, returns `nil`."
-  [[_ {:keys [l] :as path} :as loc]]
+  [{:keys [position] {:keys [l] :as path} :path :as loc}]
   (if (seq l)
-    (with-meta
-      [(peek l)
-       (-> path
-           (update-in [:l] pop)
-           (assoc :changed? true))
-       (loc 2)]
-      (meta loc))))
+    {:node (peek l)
+     :path (-> path
+               (update-in [:l] pop)
+               (assoc :changed? true))
+     :position position}))
 
 (defn remove-and-move-right
   "Remove current node and move right. If current node is at the rightmost
    location, returns `nil`."
-  [[_ {:keys [r] :as path} :as loc]]
+  [{:keys [position] {:keys [r] :as path} :path :as loc}]
   (if (seq r)
-    (with-meta
-      [(first r)
-       (-> path
-           (update-in [:r] next)
-           (assoc :changed? true))
-       (loc 2)]
-      (meta loc))))
+    {:node (first r)
+     :path (-> path
+               (update-in [:r] next)
+               (assoc :changed? true))
+     :position position}))

--- a/src/rewrite_clj/zip/utils.clj
+++ b/src/rewrite_clj/zip/utils.clj
@@ -3,16 +3,12 @@
 
 ;; ## Remove
 
-(defn- update-in-path
-  [loc k f]
-  (if-let [v (get loc k)]
-    (assoc loc :changed? true k (f v))
-    loc))
-
 (defn remove-right
   "Remove right sibling of the current node (if there is one)."
-  [loc]
-  (update-in-path loc :right next))
+  [{[r & rs] :right :as loc}]
+  (assoc loc
+         :right rs
+         :changed? true))
 
 (defn remove-left
   "Remove left sibling of the current node (if there is one)."

--- a/src/rewrite_clj/zip/utils.clj
+++ b/src/rewrite_clj/zip/utils.clj
@@ -7,10 +7,10 @@
   [{:keys [node path parent position] :as loc} k f]
   (let [v (get path k)]
     (if (seq v)
-      {:node node
-       :path (assoc path k (f v) :changed? true)
-       :parent parent
-       :position position}
+      (assoc loc
+             :changed? true
+             :node node
+             :path (assoc path k (f v)))
       loc)))
 
 (defn remove-right
@@ -52,21 +52,17 @@
    location, returns `nil`."
   [{:keys [position parent] {:keys [l] :as path} :path :as loc}]
   (if (seq l)
-    {:node (peek l)
-     :path (-> path
-               (update-in [:l] pop)
-               (assoc :changed? true))
-     :parent parent
-     :position position}))
+    (assoc loc
+           :changed? true
+           :node (peek l)
+           :path (update-in path [:l] pop))))
 
 (defn remove-and-move-right
   "Remove current node and move right. If current node is at the rightmost
    location, returns `nil`."
   [{:keys [position parent] {:keys [r] :as path} :path :as loc}]
   (if (seq r)
-    {:node (first r)
-     :path (-> path
-               (update-in [:r] next)
-               (assoc :changed? true))
-     :parent parent
-     :position position}))
+    (assoc loc
+           :changed? true
+           :node (first r)
+           :path (update-in path [:r] next))))

--- a/src/rewrite_clj/zip/utils.clj
+++ b/src/rewrite_clj/zip/utils.clj
@@ -8,7 +8,7 @@
   (let [v (get path k)]
     (if (seq v)
       (with-meta
-        [node (assoc path k (f v) :changed? true)]
+        [node (assoc path k (f v) :changed? true) (loc 2)]
         (meta loc))
       loc)))
 
@@ -52,9 +52,11 @@
   [[_ {:keys [l] :as path} :as loc]]
   (if (seq l)
     (with-meta
-      [(peek l) (-> path
-                    (update-in [:l] pop)
-                    (assoc :changed? true))]
+      [(peek l)
+       (-> path
+           (update-in [:l] pop)
+           (assoc :changed? true))
+       (loc 2)]
       (meta loc))))
 
 (defn remove-and-move-right
@@ -63,7 +65,9 @@
   [[_ {:keys [r] :as path} :as loc]]
   (if (seq r)
     (with-meta
-      [(first r) (-> path
-                     (update-in [:r] next)
-                     (assoc :changed? true))]
+      [(first r)
+       (-> path
+           (update-in [:r] next)
+           (assoc :changed? true))
+       (loc 2)]
       (meta loc))))

--- a/src/rewrite_clj/zip/utils.clj
+++ b/src/rewrite_clj/zip/utils.clj
@@ -4,11 +4,12 @@
 ;; ## Remove
 
 (defn- update-in-path
-  [{:keys [node path position] :as loc} k f]
+  [{:keys [node path parent position] :as loc} k f]
   (let [v (get path k)]
     (if (seq v)
       {:node node
        :path (assoc path k (f v) :changed? true)
+       :parent parent
        :position position}
       loc)))
 
@@ -49,21 +50,23 @@
 (defn remove-and-move-left
   "Remove current node and move left. If current node is at the leftmost
    location, returns `nil`."
-  [{:keys [position] {:keys [l] :as path} :path :as loc}]
+  [{:keys [position parent] {:keys [l] :as path} :path :as loc}]
   (if (seq l)
     {:node (peek l)
      :path (-> path
                (update-in [:l] pop)
                (assoc :changed? true))
+     :parent parent
      :position position}))
 
 (defn remove-and-move-right
   "Remove current node and move right. If current node is at the rightmost
    location, returns `nil`."
-  [{:keys [position] {:keys [r] :as path} :path :as loc}]
+  [{:keys [position parent] {:keys [r] :as path} :path :as loc}]
   (if (seq r)
     {:node (first r)
      :path (-> path
                (update-in [:r] next)
                (assoc :changed? true))
+     :parent parent
      :position position}))

--- a/src/rewrite_clj/zip/walk.clj
+++ b/src/rewrite_clj/zip/walk.clj
@@ -1,5 +1,5 @@
 (ns ^:no-doc rewrite-clj.zip.walk
-  (:require [clojure.zip :as z]
+  (:require [rewrite-clj.zip.zip :as z]
             [rewrite-clj.zip
              [subedit :refer [subedit-node]]
              [move :as m]]))

--- a/src/rewrite_clj/zip/whitespace.clj
+++ b/src/rewrite_clj/zip/whitespace.clj
@@ -1,6 +1,6 @@
 (ns ^:no-doc rewrite-clj.zip.whitespace
   (:require [rewrite-clj.node :as node]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 ;; ## Predicates
 

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -13,24 +13,14 @@
   and enumeration.  See Huet"
        :author "Rich Hickey"}
   rewrite-clj.zip.zip
-  (:refer-clojure :exclude (replace remove next)))
+  (:refer-clojure :exclude (replace remove next))
+  (:require [rewrite-clj.node :as node]))
 
 (defn zipper
-  "Creates a new zipper structure. 
-
-  branch? is a fn that, given a node, returns true if can have
-  children, even if it currently doesn't.
-
-  children is a fn that, given a branch node, returns a seq of its
-  children.
-
-  make-node is a fn that, given an existing node and a seq of
-  children, returns a new branch node with the supplied children.
-  root is the root node."
+  "Creates a new zipper structure."
   {:added "1.0"}
-  [branch? children make-node root]
-    ^{:zip/branch? branch? :zip/children children :zip/make-node make-node}
-    [root nil])
+  [root]
+  [root nil])
 
 (defn node
   "Returns the node at loc"
@@ -41,14 +31,14 @@
   "Returns true if the node at loc is a branch"
   {:added "1.0"}
   [loc]
-    ((:zip/branch? (meta loc)) (node loc)))
+    (node/inner? (node loc)))
 
 (defn children
   "Returns a seq of the children of node at loc, which must be a branch"
   {:added "1.0"}
   [loc]
     (if (branch? loc)
-      ((:zip/children (meta loc)) (node loc))
+      (seq (node/children (node loc)))
       (throw (Exception. "called children on a leaf node"))))
 
 (defn make-node
@@ -56,7 +46,7 @@
   children. The loc is only used to supply the constructor."
   {:added "1.0"}
   [loc node children]
-    ((:zip/make-node (meta loc)) node children))
+    (node/replace-children node children))
 
 (defn path
   "Returns a seq of nodes leading to this loc"

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -1,0 +1,318 @@
+;   Copyright (c) Rich Hickey. All rights reserved.
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file epl-v10.html at the root of this distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
+;functional hierarchical zipper, with navigation, editing and enumeration
+;see Huet
+
+(ns ^{:doc "Functional hierarchical zipper, with navigation, editing,
+  and enumeration.  See Huet"
+       :author "Rich Hickey"}
+  rewrite-clj.zip.zip
+  (:refer-clojure :exclude (replace remove next)))
+
+(defn zipper
+  "Creates a new zipper structure. 
+
+  branch? is a fn that, given a node, returns true if can have
+  children, even if it currently doesn't.
+
+  children is a fn that, given a branch node, returns a seq of its
+  children.
+
+  make-node is a fn that, given an existing node and a seq of
+  children, returns a new branch node with the supplied children.
+  root is the root node."
+  {:added "1.0"}
+  [branch? children make-node root]
+    ^{:zip/branch? branch? :zip/children children :zip/make-node make-node}
+    [root nil])
+
+(defn seq-zip
+  "Returns a zipper for nested sequences, given a root sequence"
+  {:added "1.0"}
+  [root]
+    (zipper seq?
+            identity
+            (fn [node children] (with-meta children (meta node)))
+            root))
+
+(defn vector-zip
+  "Returns a zipper for nested vectors, given a root vector"
+  {:added "1.0"}
+  [root]
+    (zipper vector?
+            seq
+            (fn [node children] (with-meta (vec children) (meta node)))
+            root))
+
+(defn xml-zip
+  "Returns a zipper for xml elements (as from xml/parse),
+  given a root element"
+  {:added "1.0"}
+  [root]
+    (zipper (complement string?) 
+            (comp seq :content)
+            (fn [node children]
+              (assoc node :content (and children (apply vector children))))
+            root))
+
+(defn node
+  "Returns the node at loc"
+  {:added "1.0"}
+  [loc] (loc 0))
+
+(defn branch?
+  "Returns true if the node at loc is a branch"
+  {:added "1.0"}
+  [loc]
+    ((:zip/branch? (meta loc)) (node loc)))
+
+(defn children
+  "Returns a seq of the children of node at loc, which must be a branch"
+  {:added "1.0"}
+  [loc]
+    (if (branch? loc)
+      ((:zip/children (meta loc)) (node loc))
+      (throw (Exception. "called children on a leaf node"))))
+
+(defn make-node
+  "Returns a new branch node, given an existing node and new
+  children. The loc is only used to supply the constructor."
+  {:added "1.0"}
+  [loc node children]
+    ((:zip/make-node (meta loc)) node children))
+
+(defn path
+  "Returns a seq of nodes leading to this loc"
+  {:added "1.0"}
+  [loc]
+    (:pnodes (loc 1)))
+
+(defn lefts
+  "Returns a seq of the left siblings of this loc"
+  {:added "1.0"}
+  [loc]
+    (seq (:l (loc 1))))
+
+(defn rights
+  "Returns a seq of the right siblings of this loc"
+  {:added "1.0"}
+  [loc]
+    (:r (loc 1)))
+
+
+(defn down
+  "Returns the loc of the leftmost child of the node at this loc, or
+  nil if no children"
+  {:added "1.0"}
+  [loc]
+    (when (branch? loc)
+      (let [[node path] loc
+            [c & cnext :as cs] (children loc)]
+        (when cs
+          (with-meta [c {:l [] 
+                         :pnodes (if path (conj (:pnodes path) node) [node]) 
+                         :ppath path 
+                         :r cnext}] (meta loc))))))
+
+(defn up
+  "Returns the loc of the parent of the node at this loc, or nil if at
+  the top"
+  {:added "1.0"}
+  [loc]
+    (let [[node {l :l, ppath :ppath, pnodes :pnodes r :r, changed? :changed?, :as path}] loc]
+      (when pnodes
+        (let [pnode (peek pnodes)]
+          (with-meta (if changed?
+                       [(make-node loc pnode (concat l (cons node r))) 
+                        (and ppath (assoc ppath :changed? true))]
+                       [pnode ppath])
+                     (meta loc))))))
+
+(defn root
+  "zips all the way up and returns the root node, reflecting any
+ changes."
+  {:added "1.0"}
+  [loc]
+    (if (= :end (loc 1))
+      (node loc)
+      (let [p (up loc)]
+        (if p
+          (recur p)
+          (node loc)))))
+
+(defn right
+  "Returns the loc of the right sibling of the node at this loc, or nil"
+  {:added "1.0"}
+  [loc]
+    (let [[node {l :l  [r & rnext :as rs] :r :as path}] loc]
+      (when (and path rs)
+        (with-meta [r (assoc path :l (conj l node) :r rnext)] (meta loc)))))
+
+(defn rightmost
+  "Returns the loc of the rightmost sibling of the node at this loc, or self"
+  {:added "1.0"}
+  [loc]
+    (let [[node {l :l r :r :as path}] loc]
+      (if (and path r)
+        (with-meta [(last r) (assoc path :l (apply conj l node (butlast r)) :r nil)] (meta loc))
+        loc)))
+
+(defn left
+  "Returns the loc of the left sibling of the node at this loc, or nil"
+  {:added "1.0"}
+  [loc]
+    (let [[node {l :l r :r :as path}] loc]
+      (when (and path (seq l))
+        (with-meta [(peek l) (assoc path :l (pop l) :r (cons node r))] (meta loc)))))
+
+(defn leftmost
+  "Returns the loc of the leftmost sibling of the node at this loc, or self"
+  {:added "1.0"}
+  [loc]
+    (let [[node {l :l r :r :as path}] loc]
+      (if (and path (seq l))
+        (with-meta [(first l) (assoc path :l [] :r (concat (rest l) [node] r))] (meta loc))
+        loc)))
+
+(defn insert-left
+  "Inserts the item as the left sibling of the node at this loc,
+ without moving"
+  {:added "1.0"}
+  [loc item]
+    (let [[node {l :l :as path}] loc]
+      (if (nil? path)
+        (throw (new Exception "Insert at top"))
+        (with-meta [node (assoc path :l (conj l item) :changed? true)] (meta loc)))))
+
+(defn insert-right
+  "Inserts the item as the right sibling of the node at this loc,
+  without moving"
+  {:added "1.0"}
+  [loc item]
+    (let [[node {r :r :as path}] loc]
+      (if (nil? path)
+        (throw (new Exception "Insert at top"))
+        (with-meta [node (assoc path :r (cons item r) :changed? true)] (meta loc)))))
+
+(defn replace
+  "Replaces the node at this loc, without moving"
+  {:added "1.0"}
+  [loc node]
+    (let [[_ path] loc]
+      (with-meta [node (assoc path :changed? true)] (meta loc))))
+
+(defn edit
+  "Replaces the node at this loc with the value of (f node args)"
+  {:added "1.0"}
+  [loc f & args]
+    (replace loc (apply f (node loc) args)))
+
+(defn insert-child
+  "Inserts the item as the leftmost child of the node at this loc,
+  without moving"
+  {:added "1.0"}
+  [loc item]
+    (replace loc (make-node loc (node loc) (cons item (children loc)))))
+
+(defn append-child
+  "Inserts the item as the rightmost child of the node at this loc,
+  without moving"
+  {:added "1.0"}
+  [loc item]
+    (replace loc (make-node loc (node loc) (concat (children loc) [item]))))
+
+(defn next
+  "Moves to the next loc in the hierarchy, depth-first. When reaching
+  the end, returns a distinguished loc detectable via end?. If already
+  at the end, stays there."
+  {:added "1.0"}
+  [loc]
+    (if (= :end (loc 1))
+      loc
+      (or 
+       (and (branch? loc) (down loc))
+       (right loc)
+       (loop [p loc]
+         (if (up p)
+           (or (right (up p)) (recur (up p)))
+           [(node p) :end])))))
+
+(defn prev
+  "Moves to the previous loc in the hierarchy, depth-first. If already
+  at the root, returns nil."
+  {:added "1.0"}
+  [loc]
+    (if-let [lloc (left loc)]
+      (loop [loc lloc]
+        (if-let [child (and (branch? loc) (down loc))]
+          (recur (rightmost child))
+          loc))
+      (up loc)))
+
+(defn end?
+  "Returns true if loc represents the end of a depth-first walk"
+  {:added "1.0"}
+  [loc]
+    (= :end (loc 1)))
+
+(defn remove
+  "Removes the node at loc, returning the loc that would have preceded
+  it in a depth-first walk."
+  {:added "1.0"}
+  [loc]
+    (let [[node {l :l, ppath :ppath, pnodes :pnodes, rs :r, :as path}] loc]
+      (if (nil? path)
+        (throw (new Exception "Remove at top"))
+        (if (pos? (count l))
+          (loop [loc (with-meta [(peek l) (assoc path :l (pop l) :changed? true)] (meta loc))]
+            (if-let [child (and (branch? loc) (down loc))]
+              (recur (rightmost child))
+              loc))
+          (with-meta [(make-node loc (peek pnodes) rs) 
+                      (and ppath (assoc ppath :changed? true))]
+                     (meta loc))))))
+  
+(comment
+
+(load-file "/Users/rich/dev/clojure/src/zip.clj")
+(refer 'zip)
+(def data '[[a * b] + [c * d]])
+(def dz (vector-zip data))
+
+(right (down (right (right (down dz)))))
+(lefts (right (down (right (right (down dz))))))
+(rights (right (down (right (right (down dz))))))
+(up (up (right (down (right (right (down dz)))))))
+(path (right (down (right (right (down dz))))))
+
+(-> dz down right right down right)
+(-> dz down right right down right (replace '/) root)
+(-> dz next next (edit str) next next next (replace '/) root)
+(-> dz next next next next next next next next next remove root)
+(-> dz next next next next next next next next next remove (insert-right 'e) root)
+(-> dz next next next next next next next next next remove up (append-child 'e) root)
+
+(end? (-> dz next next next next next next next next next remove next))
+
+(-> dz next remove next remove root)
+
+(loop [loc dz]
+  (if (end? loc)
+    (root loc)
+    (recur (next (if (= '* (node loc)) 
+                   (replace loc '/)
+                   loc)))))
+
+(loop [loc dz]
+  (if (end? loc)
+    (root loc)
+    (recur (next (if (= '* (node loc)) 
+                   (remove loc)
+                   loc)))))
+)

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -215,39 +215,3 @@
           [(make-node loc (peek pnodes) rs) 
                      (and ppath (assoc ppath :changed? true))
                      (loc 2)]))))
-  
-(comment
-
-(refer 'zip)
-(def data '[[a * b] + [c * d]])
-
-(right (down (right (right (down dz)))))
-(lefts (right (down (right (right (down dz))))))
-(up (up (right (down (right (right (down dz)))))))
-(path (right (down (right (right (down dz))))))
-
-(-> dz down right right down right)
-(-> dz down right right down right (replace '/) root)
-(-> dz next next (edit str) next next next (replace '/) root)
-(-> dz next next next next next next next next next remove root)
-(-> dz next next next next next next next next next remove (insert-right 'e) root)
-(-> dz next next next next next next next next next remove up (append-child 'e) root)
-
-(end? (-> dz next next next next next next next next next remove next))
-
-(-> dz next remove next remove root)
-
-(loop [loc dz]
-  (if (end? loc)
-    (root loc)
-    (recur (next (if (= '* (node loc)) 
-                   (replace loc '/)
-                   loc)))))
-
-(loop [loc dz]
-  (if (end? loc)
-    (root loc)
-    (recur (next (if (= '* (node loc)) 
-                   (remove loc)
-                   loc)))))
-)

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -131,10 +131,12 @@
   [loc]
   (let [{:keys [node parent left right]} loc]
     (if (and parent (seq left))
-      (assoc loc
-             :node (ffirst left)
-             :left []
-             :right (concat (map first (rest left)) [node] right))
+      (let [[lnode lpos] (first left)]
+        (assoc loc
+               :node lnode
+               :position lpos
+               :left []
+               :right (concat (map first (rest left)) [node] right)))
       loc)))
 
 (defn insert-left

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -94,8 +94,8 @@
 (defn root
   "zips all the way up and returns the root node, reflecting any
  changes."
-  [loc]
-  (if (= :end (:path loc))
+  [{:keys [end?] :as loc}]
+  (if end?
     (node loc)
     (let [p (up loc)]
       (if p
@@ -188,8 +188,8 @@
   "Moves to the next loc in the hierarchy, depth-first. When reaching
   the end, returns a distinguished loc detectable via end?. If already
   at the end, stays there."
-  [loc]
-  (if (= :end (:path loc))
+  [{:keys [end?] :as loc}]
+  (if end?
     loc
     (or 
      (and (branch? loc) (down loc))
@@ -197,7 +197,7 @@
      (loop [p loc]
        (if (up p)
          (or (right (up p)) (recur (up p)))
-         (assoc p :path :end))))))
+         (assoc p :end? true))))))
 
 (defn prev
   "Moves to the previous loc in the hierarchy, depth-first. If already
@@ -213,7 +213,7 @@
 (defn end?
   "Returns true if loc represents the end of a depth-first walk"
   [loc]
-  (= :end (:path loc)))
+  (:end? loc))
 
 (defn remove
   "Removes the node at loc, returning the loc that would have preceded

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -148,7 +148,8 @@
       (throw (new Exception "Insert at top"))
       (assoc loc
              :changed? true
-             :left (conj left [item position])))))
+             :left (conj left [item position])
+             :position (node/+extent position (node/extent item))))))
 
 (defn insert-right
   "Inserts the item as the right sibling of the node at this loc,

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -124,10 +124,9 @@
   "Returns the loc of the rightmost sibling of the node at this loc, or self"
   {:added "1.0"}
   [loc]
-    (let [[node {l :l r :r :as path}] loc]
-      (if (and path r)
-        (with-meta [(last r) (assoc path :l (apply conj l node (butlast r)) :r nil) (loc 2)] (meta loc))
-        loc)))
+  (if-let [next (right loc)]
+    (recur next)
+    loc))
 
 (defn left
   "Returns the loc of the left sibling of the node at this loc, or nil"

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -46,11 +46,6 @@
   [loc node children]
   (node/replace-children node children))
 
-(defn path
-  "Returns a seq of nodes leading to this loc"
-  [loc]
-  (:pnodes (:path loc)))
-
 (defn position
   "Returns [row col] of the start of the current node"
   [loc]

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -20,7 +20,7 @@
   "Creates a new zipper structure."
   {:added "1.0"}
   [root]
-  [root nil])
+  [root nil [1 1]])
 
 (defn node
   "Returns the node at loc"
@@ -53,6 +53,11 @@
   {:added "1.0"}
   [loc]
     (:pnodes (loc 1)))
+
+(defn position
+  "Returns [row col] of the start of the current node"
+  [loc]
+  (loc 2))
 
 (defn lefts
   "Returns a seq of the left siblings of this loc"

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -16,7 +16,7 @@
   (:refer-clojure :exclude (replace remove next))
   (:require [rewrite-clj.node.protocols :as node]))
 
-(defn zipper
+(defn ^:no-doc zipper
   "Creates a new zipper structure."
   [root]
   {:node root
@@ -42,14 +42,14 @@
     (seq (node/children node))
     (throw (Exception. "called children on a leaf node"))))
 
-(defn make-node
+(defn ^:no-doc make-node
   "Returns a new branch node, given an existing node and new
   children. The loc is only used to supply the constructor."
   [loc node children]
   (node/replace-children node children))
 
 (defn position
-  "Returns [row col] of the start of the current node"
+  "Returns the ones-based [row col] of the start of the current node"
   [loc]
   (:position loc))
 

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -190,7 +190,7 @@
   [{:keys [end?] :as loc}]
   (if end?
     loc
-    (or 
+    (or
      (and (branch? loc) (down loc))
      (right loc)
      (loop [p loc]
@@ -229,7 +229,7 @@
           (if-let [child (and (branch? loc) (down loc))]
             (recur (rightmost child))
             loc))
-        {:node (make-node loc (:node parent) r) 
+        {:node (make-node loc (:node parent) r)
          :path (and ppath (assoc ppath :changed? true))
          :parent (:parent parent)
          :position position}))))

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -154,7 +154,7 @@
   "Inserts the item as the right sibling of the node at this loc,
   without moving"
   [loc item]
-  (let [{:keys [node parent right]} loc]
+  (let [{:keys [parent right]} loc]
     (if-not parent
       (throw (new Exception "Insert at top"))
       (assoc loc

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -18,24 +18,20 @@
 
 (defn zipper
   "Creates a new zipper structure."
-  {:added "1.0"}
   [root]
   [root nil [1 1]])
 
 (defn node
   "Returns the node at loc"
-  {:added "1.0"}
   [loc] (loc 0))
 
 (defn branch?
   "Returns true if the node at loc is a branch"
-  {:added "1.0"}
   [loc]
     (node/inner? (node loc)))
 
 (defn children
   "Returns a seq of the children of node at loc, which must be a branch"
-  {:added "1.0"}
   [loc]
     (if (branch? loc)
       (seq (node/children (node loc)))
@@ -44,13 +40,11 @@
 (defn make-node
   "Returns a new branch node, given an existing node and new
   children. The loc is only used to supply the constructor."
-  {:added "1.0"}
   [loc node children]
     (node/replace-children node children))
 
 (defn path
   "Returns a seq of nodes leading to this loc"
-  {:added "1.0"}
   [loc]
     (:pnodes (loc 1)))
 
@@ -61,14 +55,12 @@
 
 (defn lefts
   "Returns a seq of the left siblings of this loc"
-  {:added "1.0"}
   [loc]
     (seq (:l (loc 1))))
 
 (defn down
   "Returns the loc of the leftmost child of the node at this loc, or
   nil if no children"
-  {:added "1.0"}
   [loc]
     (when (branch? loc)
       (let [[node path [row col]] loc
@@ -84,7 +76,6 @@
 (defn up
   "Returns the loc of the parent of the node at this loc, or nil if at
   the top"
-  {:added "1.0"}
   [loc]
     (let [[node {l :l, ppath :ppath, pnodes :pnodes r :r, changed? :changed?, :as path}] loc]
       (when pnodes
@@ -98,7 +89,6 @@
 (defn root
   "zips all the way up and returns the root node, reflecting any
  changes."
-  {:added "1.0"}
   [loc]
     (if (= :end (loc 1))
       (node loc)
@@ -109,7 +99,6 @@
 
 (defn right
   "Returns the loc of the right sibling of the node at this loc, or nil"
-  {:added "1.0"}
   [loc]
     (let [[node {l :l  [r & rnext :as rs] :r :as path} pos] loc]
       (when (and path rs)
@@ -119,7 +108,6 @@
 
 (defn rightmost
   "Returns the loc of the rightmost sibling of the node at this loc, or self"
-  {:added "1.0"}
   [loc]
   (if-let [next (right loc)]
     (recur next)
@@ -127,7 +115,6 @@
 
 (defn left
   "Returns the loc of the left sibling of the node at this loc, or nil"
-  {:added "1.0"}
   [loc]
     (let [[node {l :l r :r :as path}] loc]
       (when (and path (seq l))
@@ -135,7 +122,6 @@
 
 (defn leftmost
   "Returns the loc of the leftmost sibling of the node at this loc, or self"
-  {:added "1.0"}
   [loc]
     (let [[node {l :l r :r :as path}] loc]
       (if (and path (seq l))
@@ -145,7 +131,6 @@
 (defn insert-left
   "Inserts the item as the left sibling of the node at this loc,
  without moving"
-  {:added "1.0"}
   [loc item]
     (let [[node {l :l :as path}] loc]
       (if (nil? path)
@@ -155,7 +140,6 @@
 (defn insert-right
   "Inserts the item as the right sibling of the node at this loc,
   without moving"
-  {:added "1.0"}
   [loc item]
     (let [[node {r :r :as path}] loc]
       (if (nil? path)
@@ -164,28 +148,24 @@
 
 (defn replace
   "Replaces the node at this loc, without moving"
-  {:added "1.0"}
   [loc node]
     (let [[_ path] loc]
       [node (assoc path :changed? true) (loc 2)]))
 
 (defn edit
   "Replaces the node at this loc with the value of (f node args)"
-  {:added "1.0"}
   [loc f & args]
     (replace loc (apply f (node loc) args)))
 
 (defn insert-child
   "Inserts the item as the leftmost child of the node at this loc,
   without moving"
-  {:added "1.0"}
   [loc item]
     (replace loc (make-node loc (node loc) (cons item (children loc)))))
 
 (defn append-child
   "Inserts the item as the rightmost child of the node at this loc,
   without moving"
-  {:added "1.0"}
   [loc item]
     (replace loc (make-node loc (node loc) (concat (children loc) [item]))))
 
@@ -193,7 +173,6 @@
   "Moves to the next loc in the hierarchy, depth-first. When reaching
   the end, returns a distinguished loc detectable via end?. If already
   at the end, stays there."
-  {:added "1.0"}
   [loc]
     (if (= :end (loc 1))
       loc
@@ -208,7 +187,6 @@
 (defn prev
   "Moves to the previous loc in the hierarchy, depth-first. If already
   at the root, returns nil."
-  {:added "1.0"}
   [loc]
     (if-let [lloc (left loc)]
       (loop [loc lloc]
@@ -219,14 +197,12 @@
 
 (defn end?
   "Returns true if loc represents the end of a depth-first walk"
-  {:added "1.0"}
   [loc]
     (= :end (loc 1)))
 
 (defn remove
   "Removes the node at loc, returning the loc that would have preceded
   it in a depth-first walk."
-  {:added "1.0"}
   [loc]
     (let [[node {l :l, ppath :ppath, pnodes :pnodes, rs :r, :as path}] loc]
       (if (nil? path)

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -68,19 +68,18 @@
         {:node c
          :position [row (+ col (node/leader-length node))]
          :parent loc
-         :path {:l [] 
-                :pnodes (if path (conj (:pnodes path) node) [node]) 
-                :ppath path 
+         :path {:l []
+                :ppath path
                 :r cnext}}))))
 
 (defn up
   "Returns the loc of the parent of the node at this loc, or nil if at
   the top"
   [loc]
-  (let [{:keys [node parent position] {:keys [l ppath pnodes r changed?]} :path} loc]
+  (let [{:keys [node parent position] {:keys [l ppath r changed?]} :path} loc]
     (when parent
       (if changed?
-        {:node (make-node loc (peek pnodes) (concat l (cons node r)))
+        {:node (make-node loc (:node parent) (concat l (cons node r)))
          :path (and ppath (assoc ppath :changed? true))
          :parent (:parent parent)
          :position position}
@@ -219,7 +218,7 @@
   "Removes the node at loc, returning the loc that would have preceded
   it in a depth-first walk."
   [loc]
-  (let [{:keys [node parent position] {:keys [l ppath pnodes r] :as path} :path} loc]
+  (let [{:keys [node parent position] {:keys [l ppath r] :as path} :path} loc]
     (if (nil? path)
       (throw (new Exception "Remove at top"))
       (if (pos? (count l))
@@ -230,7 +229,7 @@
           (if-let [child (and (branch? loc) (down loc))]
             (recur (rightmost child))
             loc))
-        {:node (make-node loc (peek pnodes) r) 
+        {:node (make-node loc (:node parent) r) 
          :path (and ppath (assoc ppath :changed? true))
          :parent (:parent parent)
          :position position}))))

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -32,15 +32,6 @@
     ^{:zip/branch? branch? :zip/children children :zip/make-node make-node}
     [root nil])
 
-(defn seq-zip
-  "Returns a zipper for nested sequences, given a root sequence"
-  {:added "1.0"}
-  [root]
-    (zipper seq?
-            identity
-            (fn [node children] (with-meta children (meta node)))
-            root))
-
 (defn vector-zip
   "Returns a zipper for nested vectors, given a root vector"
   {:added "1.0"}
@@ -48,17 +39,6 @@
     (zipper vector?
             seq
             (fn [node children] (with-meta (vec children) (meta node)))
-            root))
-
-(defn xml-zip
-  "Returns a zipper for xml elements (as from xml/parse),
-  given a root element"
-  {:added "1.0"}
-  [root]
-    (zipper (complement string?) 
-            (comp seq :content)
-            (fn [node children]
-              (assoc node :content (and children (apply vector children))))
             root))
 
 (defn node
@@ -98,13 +78,6 @@
   {:added "1.0"}
   [loc]
     (seq (:l (loc 1))))
-
-(defn rights
-  "Returns a seq of the right siblings of this loc"
-  {:added "1.0"}
-  [loc]
-    (:r (loc 1)))
-
 
 (defn down
   "Returns the loc of the leftmost child of the node at this loc, or
@@ -280,14 +253,12 @@
   
 (comment
 
-(load-file "/Users/rich/dev/clojure/src/zip.clj")
 (refer 'zip)
 (def data '[[a * b] + [c * d]])
 (def dz (vector-zip data))
 
 (right (down (right (right (down dz)))))
 (lefts (right (down (right (right (down dz))))))
-(rights (right (down (right (right (down dz))))))
 (up (up (right (down (right (right (down dz)))))))
 (path (right (down (right (right (down dz))))))
 

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -113,9 +113,12 @@
   "Returns the loc of the right sibling of the node at this loc, or nil"
   {:added "1.0"}
   [loc]
-    (let [[node {l :l  [r & rnext :as rs] :r :as path}] loc]
+    (let [[node {l :l  [r & rnext :as rs] :r :as path} pos] loc]
       (when (and path rs)
-        (with-meta [r (assoc path :l (conj l node) :r rnext) (loc 2)] (meta loc)))))
+        (with-meta [r
+                    (assoc path :l (conj l node) :r rnext)
+                    (node/+extent pos (node/extent node))]
+                   (meta loc)))))
 
 (defn rightmost
   "Returns the loc of the rightmost sibling of the node at this loc, or self"

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -74,13 +74,12 @@
       (let [[node path [row col]] loc
             [c & cnext :as cs] (children loc)]
         (when cs
-          (with-meta [c
-                      {:l [] 
-                       :pnodes (if path (conj (:pnodes path) node) [node]) 
-                       :ppath path 
-                       :r cnext}
-                      [row (+ col (node/leader-length node))]]
-                     (meta loc))))))
+          [c
+           {:l [] 
+            :pnodes (if path (conj (:pnodes path) node) [node]) 
+            :ppath path 
+            :r cnext}
+           [row (+ col (node/leader-length node))]]))))
 
 (defn up
   "Returns the loc of the parent of the node at this loc, or nil if at
@@ -90,12 +89,11 @@
     (let [[node {l :l, ppath :ppath, pnodes :pnodes r :r, changed? :changed?, :as path}] loc]
       (when pnodes
         (let [pnode (peek pnodes)]
-          (with-meta (if changed?
-                       [(make-node loc pnode (concat l (cons node r))) 
-                        (and ppath (assoc ppath :changed? true))
-                        (loc 2)]
-                       [pnode ppath (loc 2)])
-                     (meta loc))))))
+          (if changed?
+            [(make-node loc pnode (concat l (cons node r))) 
+             (and ppath (assoc ppath :changed? true))
+             (loc 2)]
+            [pnode ppath (loc 2)])))))
 
 (defn root
   "zips all the way up and returns the root node, reflecting any
@@ -115,10 +113,9 @@
   [loc]
     (let [[node {l :l  [r & rnext :as rs] :r :as path} pos] loc]
       (when (and path rs)
-        (with-meta [r
-                    (assoc path :l (conj l node) :r rnext)
-                    (node/+extent pos (node/extent node))]
-                   (meta loc)))))
+        [r
+         (assoc path :l (conj l node) :r rnext)
+         (node/+extent pos (node/extent node))])))
 
 (defn rightmost
   "Returns the loc of the rightmost sibling of the node at this loc, or self"
@@ -134,7 +131,7 @@
   [loc]
     (let [[node {l :l r :r :as path}] loc]
       (when (and path (seq l))
-        (with-meta [(peek l) (assoc path :l (pop l) :r (cons node r)) (loc 2)] (meta loc)))))
+        [(peek l) (assoc path :l (pop l) :r (cons node r)) (loc 2)])))
 
 (defn leftmost
   "Returns the loc of the leftmost sibling of the node at this loc, or self"
@@ -142,7 +139,7 @@
   [loc]
     (let [[node {l :l r :r :as path}] loc]
       (if (and path (seq l))
-        (with-meta [(first l) (assoc path :l [] :r (concat (rest l) [node] r)) (loc 2)] (meta loc))
+        [(first l) (assoc path :l [] :r (concat (rest l) [node] r)) (loc 2)]
         loc)))
 
 (defn insert-left
@@ -153,7 +150,7 @@
     (let [[node {l :l :as path}] loc]
       (if (nil? path)
         (throw (new Exception "Insert at top"))
-        (with-meta [node (assoc path :l (conj l item) :changed? true) (loc 2)] (meta loc)))))
+        [node (assoc path :l (conj l item) :changed? true) (loc 2)])))
 
 (defn insert-right
   "Inserts the item as the right sibling of the node at this loc,
@@ -163,14 +160,14 @@
     (let [[node {r :r :as path}] loc]
       (if (nil? path)
         (throw (new Exception "Insert at top"))
-        (with-meta [node (assoc path :r (cons item r) :changed? true) (loc 2)] (meta loc)))))
+        [node (assoc path :r (cons item r) :changed? true) (loc 2)])))
 
 (defn replace
   "Replaces the node at this loc, without moving"
   {:added "1.0"}
   [loc node]
     (let [[_ path] loc]
-      (with-meta [node (assoc path :changed? true) (loc 2)] (meta loc))))
+      [node (assoc path :changed? true) (loc 2)]))
 
 (defn edit
   "Replaces the node at this loc with the value of (f node args)"
@@ -235,14 +232,13 @@
       (if (nil? path)
         (throw (new Exception "Remove at top"))
         (if (pos? (count l))
-          (loop [loc (with-meta [(peek l) (assoc path :l (pop l) :changed? true) (loc 2)] (meta loc))]
+          (loop [loc [(peek l) (assoc path :l (pop l) :changed? true) (loc 2)]]
             (if-let [child (and (branch? loc) (down loc))]
               (recur (rightmost child))
               loc))
-          (with-meta [(make-node loc (peek pnodes) rs) 
-                      (and ppath (assoc ppath :changed? true))
-                      (loc 2)]
-                     (meta loc))))))
+          [(make-node loc (peek pnodes) rs) 
+                     (and ppath (assoc ppath :changed? true))
+                     (loc 2)]))))
   
 (comment
 

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -14,7 +14,7 @@
        :author "Rich Hickey"}
   rewrite-clj.zip.zip
   (:refer-clojure :exclude (replace remove next))
-  (:require [rewrite-clj.node :as node]))
+  (:require [rewrite-clj.node.protocols :as node]))
 
 (defn zipper
   "Creates a new zipper structure."
@@ -71,14 +71,16 @@
   {:added "1.0"}
   [loc]
     (when (branch? loc)
-      (let [[node path] loc
+      (let [[node path [row col]] loc
             [c & cnext :as cs] (children loc)]
         (when cs
-          (with-meta [c {:l [] 
-                         :pnodes (if path (conj (:pnodes path) node) [node]) 
-                         :ppath path 
-                         :r cnext}
-                      (loc 2)] (meta loc))))))
+          (with-meta [c
+                      {:l [] 
+                       :pnodes (if path (conj (:pnodes path) node) [node]) 
+                       :ppath path 
+                       :r cnext}
+                      [row (+ col (node/leader-length node))]]
+                     (meta loc))))))
 
 (defn up
   "Returns the loc of the parent of the node at this loc, or nil if at

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -19,92 +19,97 @@
 (defn zipper
   "Creates a new zipper structure."
   [root]
-  [root nil [1 1]])
+  {:node root
+   :position [1 1]
+   :path nil})
 
 (defn node
   "Returns the node at loc"
-  [loc] (loc 0))
+  [{:keys [node]}]
+  node)
 
 (defn branch?
   "Returns true if the node at loc is a branch"
-  [loc]
-    (node/inner? (node loc)))
+  [{:keys [node]}]
+  (node/inner? node))
 
 (defn children
   "Returns a seq of the children of node at loc, which must be a branch"
-  [loc]
-    (if (branch? loc)
-      (seq (node/children (node loc)))
-      (throw (Exception. "called children on a leaf node"))))
+  [{:keys [node] :as loc}]
+  (if (branch? loc)
+    (seq (node/children node))
+    (throw (Exception. "called children on a leaf node"))))
 
 (defn make-node
   "Returns a new branch node, given an existing node and new
   children. The loc is only used to supply the constructor."
   [loc node children]
-    (node/replace-children node children))
+  (node/replace-children node children))
 
 (defn path
   "Returns a seq of nodes leading to this loc"
   [loc]
-    (:pnodes (loc 1)))
+  (:pnodes (:path loc)))
 
 (defn position
   "Returns [row col] of the start of the current node"
   [loc]
-  (loc 2))
+  (:position loc))
 
 (defn lefts
   "Returns a seq of the left siblings of this loc"
   [loc]
-    (seq (:l (loc 1))))
+  (seq (:l (:path loc))))
 
 (defn down
   "Returns the loc of the leftmost child of the node at this loc, or
   nil if no children"
   [loc]
-    (when (branch? loc)
-      (let [[node path [row col]] loc
-            [c & cnext :as cs] (children loc)]
-        (when cs
-          [c
-           {:l [] 
-            :pnodes (if path (conj (:pnodes path) node) [node]) 
-            :ppath path 
-            :r cnext}
-           [row (+ col (node/leader-length node))]]))))
+  (when (branch? loc)
+    (let [{:keys [node path] [row col] :position} loc
+          [c & cnext :as cs] (children loc)]
+      (when cs
+        {:node c
+         :position [row (+ col (node/leader-length node))]
+         :path {:l [] 
+                :pnodes (if path (conj (:pnodes path) node) [node]) 
+                :ppath path 
+                :r cnext}}))))
 
 (defn up
   "Returns the loc of the parent of the node at this loc, or nil if at
   the top"
   [loc]
-    (let [[node {l :l, ppath :ppath, pnodes :pnodes r :r, changed? :changed?, :as path}] loc]
+    (let [{:keys [node position] {:keys [l ppath pnodes r changed?]} :path} loc]
       (when pnodes
         (let [pnode (peek pnodes)]
           (if changed?
-            [(make-node loc pnode (concat l (cons node r))) 
-             (and ppath (assoc ppath :changed? true))
-             (loc 2)]
-            [pnode ppath (loc 2)])))))
+            {:node (make-node loc pnode (concat l (cons node r))) 
+             :path (and ppath (assoc ppath :changed? true))
+             :position position}
+            {:node pnode
+             :path ppath
+             :position position})))))
 
 (defn root
   "zips all the way up and returns the root node, reflecting any
  changes."
   [loc]
-    (if (= :end (loc 1))
-      (node loc)
-      (let [p (up loc)]
-        (if p
-          (recur p)
-          (node loc)))))
+  (if (= :end (:path loc))
+    (node loc)
+    (let [p (up loc)]
+      (if p
+        (recur p)
+        (node loc)))))
 
 (defn right
   "Returns the loc of the right sibling of the node at this loc, or nil"
   [loc]
-    (let [[node {l :l  [r & rnext :as rs] :r :as path} pos] loc]
-      (when (and path rs)
-        [r
-         (assoc path :l (conj l node) :r rnext)
-         (node/+extent pos (node/extent node))])))
+  (let [{:keys [node position] {l :l [r & rnext :as rs] :r :as path} :path} loc]
+    (when (and path rs)
+      {:node r
+       :path (assoc path :l (conj l node) :r rnext)
+       :position (node/+extent position (node/extent node))})))
 
 (defn rightmost
   "Returns the loc of the rightmost sibling of the node at this loc, or self"
@@ -116,102 +121,114 @@
 (defn left
   "Returns the loc of the left sibling of the node at this loc, or nil"
   [loc]
-    (let [[node {l :l r :r :as path}] loc]
-      (when (and path (seq l))
-        [(peek l) (assoc path :l (pop l) :r (cons node r)) (loc 2)])))
+  (let [{:keys [node position] {:keys [l r] :as path} :path} loc]
+    (when (and path (seq l))
+      {:node (peek l)
+       :path (assoc path :l (pop l) :r (cons node r))
+       :position position})))
 
 (defn leftmost
   "Returns the loc of the leftmost sibling of the node at this loc, or self"
   [loc]
-    (let [[node {l :l r :r :as path}] loc]
-      (if (and path (seq l))
-        [(first l) (assoc path :l [] :r (concat (rest l) [node] r)) (loc 2)]
-        loc)))
+  (let [{:keys [node position] {:keys [l r] :as path} :path} loc]
+    (if (and path (seq l))
+      {:node (first l)
+       :path (assoc path :l [] :r (concat (rest l) [node] r))
+       :position position}
+      loc)))
 
 (defn insert-left
   "Inserts the item as the left sibling of the node at this loc,
  without moving"
   [loc item]
-    (let [[node {l :l :as path}] loc]
+    (let [{:keys [node position] {:keys [l] :as path} :path} loc]
       (if (nil? path)
         (throw (new Exception "Insert at top"))
-        [node (assoc path :l (conj l item) :changed? true) (loc 2)])))
+        {:node node
+         :path (assoc path :l (conj l item) :changed? true)
+         :position position})))
 
 (defn insert-right
   "Inserts the item as the right sibling of the node at this loc,
   without moving"
   [loc item]
-    (let [[node {r :r :as path}] loc]
-      (if (nil? path)
-        (throw (new Exception "Insert at top"))
-        [node (assoc path :r (cons item r) :changed? true) (loc 2)])))
+  (let [{:keys [node position] {:keys [r] :as path} :path} loc]
+    (if (nil? path)
+      (throw (new Exception "Insert at top"))
+      {:node node
+       :path (assoc path :r (cons item r) :changed? true)
+       :position position})))
 
 (defn replace
   "Replaces the node at this loc, without moving"
   [loc node]
-    (let [[_ path] loc]
-      [node (assoc path :changed? true) (loc 2)]))
+  (let [{:keys [path]} loc]
+    (assoc loc
+           :node node
+           :path (assoc path :changed? true))))
 
 (defn edit
   "Replaces the node at this loc with the value of (f node args)"
   [loc f & args]
-    (replace loc (apply f (node loc) args)))
+  (replace loc (apply f (node loc) args)))
 
 (defn insert-child
   "Inserts the item as the leftmost child of the node at this loc,
   without moving"
   [loc item]
-    (replace loc (make-node loc (node loc) (cons item (children loc)))))
+  (replace loc (make-node loc (node loc) (cons item (children loc)))))
 
 (defn append-child
   "Inserts the item as the rightmost child of the node at this loc,
   without moving"
   [loc item]
-    (replace loc (make-node loc (node loc) (concat (children loc) [item]))))
+  (replace loc (make-node loc (node loc) (concat (children loc) [item]))))
 
 (defn next
   "Moves to the next loc in the hierarchy, depth-first. When reaching
   the end, returns a distinguished loc detectable via end?. If already
   at the end, stays there."
   [loc]
-    (if (= :end (loc 1))
-      loc
-      (or 
-       (and (branch? loc) (down loc))
-       (right loc)
-       (loop [p loc]
-         (if (up p)
-           (or (right (up p)) (recur (up p)))
-           [(node p) :end (loc 2)])))))
+  (if (= :end (:path loc))
+    loc
+    (or 
+     (and (branch? loc) (down loc))
+     (right loc)
+     (loop [p loc]
+       (if (up p)
+         (or (right (up p)) (recur (up p)))
+         (assoc p :path :end))))))
 
 (defn prev
   "Moves to the previous loc in the hierarchy, depth-first. If already
   at the root, returns nil."
   [loc]
-    (if-let [lloc (left loc)]
-      (loop [loc lloc]
-        (if-let [child (and (branch? loc) (down loc))]
-          (recur (rightmost child))
-          loc))
-      (up loc)))
+  (if-let [lloc (left loc)]
+    (loop [loc lloc]
+      (if-let [child (and (branch? loc) (down loc))]
+        (recur (rightmost child))
+        loc))
+    (up loc)))
 
 (defn end?
   "Returns true if loc represents the end of a depth-first walk"
   [loc]
-    (= :end (loc 1)))
+  (= :end (:path loc)))
 
 (defn remove
   "Removes the node at loc, returning the loc that would have preceded
   it in a depth-first walk."
   [loc]
-    (let [[node {l :l, ppath :ppath, pnodes :pnodes, rs :r, :as path}] loc]
-      (if (nil? path)
-        (throw (new Exception "Remove at top"))
-        (if (pos? (count l))
-          (loop [loc [(peek l) (assoc path :l (pop l) :changed? true) (loc 2)]]
-            (if-let [child (and (branch? loc) (down loc))]
-              (recur (rightmost child))
-              loc))
-          [(make-node loc (peek pnodes) rs) 
-                     (and ppath (assoc ppath :changed? true))
-                     (loc 2)]))))
+  (let [{:keys [node position] {:keys [l ppath pnodes r] :as path} :path} loc]
+    (if (nil? path)
+      (throw (new Exception "Remove at top"))
+      (if (pos? (count l))
+        (loop [loc {:node (peek l)
+                    :path (assoc path :l (pop l) :changed? true)
+                    :position position}]
+          (if-let [child (and (branch? loc) (down loc))]
+            (recur (rightmost child))
+            loc))
+        {:node (make-node loc (peek pnodes) r) 
+         :path (and ppath (assoc ppath :changed? true))
+         :position position}))))

--- a/src/rewrite_clj/zip/zip.clj
+++ b/src/rewrite_clj/zip/zip.clj
@@ -32,15 +32,6 @@
     ^{:zip/branch? branch? :zip/children children :zip/make-node make-node}
     [root nil])
 
-(defn vector-zip
-  "Returns a zipper for nested vectors, given a root vector"
-  {:added "1.0"}
-  [root]
-    (zipper vector?
-            seq
-            (fn [node children] (with-meta (vec children) (meta node)))
-            root))
-
 (defn node
   "Returns the node at loc"
   {:added "1.0"}
@@ -255,7 +246,6 @@
 
 (refer 'zip)
 (def data '[[a * b] + [c * d]])
-(def dz (vector-zip data))
 
 (right (down (right (right (down dz)))))
 (lefts (right (down (right (right (down dz))))))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -117,6 +117,25 @@
         (gen/vector (gen/choose 0 Long/MAX_VALUE) (+ max (inc max)))))))
 
 (defn node
+  "Generate parse nodes at random.
+  
+  `types` is a set of permissable top-level nodes.  If not specified, all
+  known top-level nodes are allowed.  This does not affect non-top-level
+  nodes.
+  
+  `depth` is the maximum depth of the tree.  It's possible the tree will be
+  shallower if we pick a lot of leaf-type nodes, but this is a limit.  If
+  not specified, the generator will pick depths from 1 through 5 at random.
+
+  Current implementation notes:
+
+   1. There's no attempt to nest things correctly.  For example, `#( ... )`
+      forms may be nested, and unquote operators may appear outside
+      syntax-quote forms.
+
+   2. Spaces and newlines are added at random, not in a smart way that
+      allows the tree to be converted to a string and reparsed.  Symbols
+      and constants will probably run together."
   ([]
    (node all-node-types))
   ([types]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -54,7 +54,6 @@
 
 ;; Container nodes
 
-;;eval-node
 ;;reader-macro-node
 ;;uneval-node
 ;;unquote-node
@@ -63,6 +62,7 @@
 (def ^:private containers
   [;ctor                     min max
    [#'node/deref-node        1   1]
+   [#'node/eval-node         1   1]
    [#'node/fn-node           1   5]
    [#'node/forms-node        0   5]
    [#'node/list-node         0   5]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -87,6 +87,3 @@
           (partial container* inner)
           containers)))
     atom-node))
-
-(def children
-  (gen/vector node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -68,7 +68,6 @@
 ;; Container nodes
 
 ;;fn-node
-;;list-node
 ;;map-node
 ;;meta-node
 ;;raw-meta-node
@@ -76,6 +75,10 @@
 (defn forms-node*
   [child-generator]
   (gen/fmap node/forms-node (gen/vector child-generator)))
+
+(defn list-node*
+  [child-generator]
+  (gen/fmap node/list-node (gen/vector child-generator)))
 
 (defn set-node*
   [child-generator]
@@ -88,6 +91,7 @@
 (defn container-node
   [inner-generator]
   (gen/one-of [(forms-node* inner-generator)
+               (list-node* inner-generator)
                (set-node* inner-generator)
                (vector-node* inner-generator)]))
 
@@ -98,5 +102,6 @@
   (gen/vector node))
 
 (def forms-node (forms-node* node))
+(def list-node (list-node* node))
 (def set-node (set-node* node))
 (def vector-node (vector-node* node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -55,7 +55,6 @@
 ;; Container nodes
 
 ;;eval-node
-;;meta-node
 ;;raw-meta-node
 ;;reader-macro-node
 ;;uneval-node
@@ -69,6 +68,7 @@
    [#'node/forms-node        0   5]
    [#'node/list-node         0   5]
    [#'node/map-node          0   5]
+   [#'node/meta-node         2   2]
    [#'node/quote-node        1   1]
    [#'node/set-node          0   5]
    [#'node/syntax-quote-node 1   1]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -55,25 +55,25 @@
 ;; Container nodes
 
 ;;eval-node
-;;fn-node
 ;;meta-node
 ;;raw-meta-node
 ;;reader-macro-node
-;;syntax-quote-node
 ;;uneval-node
 ;;unquote-node
 ;;unquote-splicing-node
 
 (def ^:private containers
-  [;ctor               min max
-   [#'node/deref-node  1   1]
-   [#'node/forms-node  0   5]
-   [#'node/list-node   0   5]
-   [#'node/map-node    0   5]
-   [#'node/quote-node  1   1]
-   [#'node/set-node    0   5]
-   [#'node/var-node    1   1]
-   [#'node/vector-node 0   5]])
+  [;ctor                     min max
+   [#'node/deref-node        1   1]
+   [#'node/fn-node           1   5]
+   [#'node/forms-node        0   5]
+   [#'node/list-node         0   5]
+   [#'node/map-node          0   5]
+   [#'node/quote-node        1   1]
+   [#'node/set-node          0   5]
+   [#'node/syntax-quote-node 1   1]
+   [#'node/var-node          1   1]
+   [#'node/vector-node       0   5]])
 
 (defn- container*
   [child-generator [ctor min max]]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -30,16 +30,6 @@
       gen/keyword
       gen/boolean)))
 
-;;deref-node
-;;eval-node
-;;reader-macro-node
-;;var-node
-;;quote-node
-;;syntax-quote-node
-;;unquote-node
-;;unquote-splicing-node
-;;uneval-node
-
 (def newline-node
   (gen/fmap
     (comp node/newline-node (partial apply str))
@@ -67,9 +57,18 @@
 
 ;; Container nodes
 
+;;deref-node
+;;eval-node
 ;;fn-node
 ;;meta-node
+;;quote-node
 ;;raw-meta-node
+;;reader-macro-node
+;;syntax-quote-node
+;;uneval-node
+;;unquote-node
+;;unquote-splicing-node
+;;var-node
 
 (defn forms-node*
   [child-generator]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -76,8 +76,8 @@
 ;;vector-node
 
 (defn forms-node*
-  [children-generator]
-  (gen/fmap node/forms-node children-generator))
+  [child-generator]
+  (gen/fmap node/forms-node (gen/vector child-generator)))
 
 (defn container-node
   [inner-generator]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -72,11 +72,14 @@
 ;;map-node
 ;;meta-node
 ;;raw-meta-node
-;;set-node
 
 (defn forms-node*
   [child-generator]
   (gen/fmap node/forms-node (gen/vector child-generator)))
+
+(defn set-node*
+  [child-generator]
+  (gen/fmap node/set-node (gen/vector child-generator)))
 
 (defn vector-node*
   [child-generator]
@@ -85,6 +88,7 @@
 (defn container-node
   [inner-generator]
   (gen/one-of [(forms-node* inner-generator)
+               (set-node* inner-generator)
                (vector-node* inner-generator)]))
 
 (def node
@@ -94,4 +98,5 @@
   (gen/vector node))
 
 (def forms-node (forms-node* children))
+(def set-node (set-node* children))
 (def vector-node (vector-node* children))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -97,6 +97,6 @@
 (def children
   (gen/vector node))
 
-(def forms-node (forms-node* children))
-(def set-node (set-node* children))
-(def vector-node (vector-node* children))
+(def forms-node (forms-node* node))
+(def set-node (set-node* node))
+(def vector-node (vector-node* node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -56,7 +56,6 @@
 
 ;;reader-macro-node
 ;;uneval-node
-;;unquote-node
 
 (def ^:private containers
   [;ctor                         min max
@@ -71,6 +70,7 @@
    [#'node/raw-meta-node         2   2]
    [#'node/set-node              0   5]
    [#'node/syntax-quote-node     1   1]
+   [#'node/unquote-node          1   1]
    [#'node/unquote-splicing-node 1   1]
    [#'node/var-node              1   1]
    [#'node/vector-node           0   5]])

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -54,8 +54,7 @@
 
 ;; Container nodes
 
-;;reader-macro-node
-;;uneval-node
+;;uneval-node       (???)
 
 (def ^:private containers
   [;ctor                         min max
@@ -68,6 +67,7 @@
    [#'node/meta-node             2   2]
    [#'node/quote-node            1   1]
    [#'node/raw-meta-node         2   2]
+   [#'node/reader-macro-node     2   2]
    [#'node/set-node              0   5]
    [#'node/syntax-quote-node     1   1]
    [#'node/unquote-node          1   1]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -68,7 +68,6 @@
 ;; Container nodes
 
 ;;fn-node
-;;map-node
 ;;meta-node
 ;;raw-meta-node
 
@@ -79,6 +78,11 @@
 (defn list-node*
   [child-generator]
   (gen/fmap node/list-node (gen/vector child-generator)))
+
+;; TODO: Ensure an even number of non-whitespace nodes
+(defn map-node*
+  [child-generator]
+  (gen/fmap node/map-node (gen/vector child-generator)))
 
 (defn set-node*
   [child-generator]
@@ -92,6 +96,7 @@
   [inner-generator]
   (gen/one-of [(forms-node* inner-generator)
                (list-node* inner-generator)
+               (map-node* inner-generator)
                (set-node* inner-generator)
                (vector-node* inner-generator)]))
 
@@ -103,5 +108,6 @@
 
 (def forms-node (forms-node* node))
 (def list-node (list-node* node))
+(def map-node (map-node* node))
 (def set-node (set-node* node))
 (def vector-node (vector-node* node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -55,7 +55,6 @@
 ;; Container nodes
 
 ;;eval-node
-;;raw-meta-node
 ;;reader-macro-node
 ;;uneval-node
 ;;unquote-node
@@ -70,6 +69,7 @@
    [#'node/map-node          0   5]
    [#'node/meta-node         2   2]
    [#'node/quote-node        1   1]
+   [#'node/raw-meta-node     2   2]
    [#'node/set-node          0   5]
    [#'node/syntax-quote-node 1   1]
    [#'node/var-node          1   1]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -54,8 +54,6 @@
 
 ;; Container nodes
 
-;;uneval-node       (???)
-
 (def ^:private containers
   [;ctor                         min max
    [#'node/deref-node            1   1]
@@ -70,6 +68,7 @@
    [#'node/reader-macro-node     2   2]
    [#'node/set-node              0   5]
    [#'node/syntax-quote-node     1   1]
+   [#'node/uneval-node           1   1]
    [#'node/unquote-node          1   1]
    [#'node/unquote-splicing-node 1   1]
    [#'node/var-node              1   1]
@@ -77,7 +76,13 @@
 
 (defn- container*
   [child-generator [ctor min max]]
-  (gen/fmap ctor (gen/vector child-generator min max)))
+  (gen/fmap
+    ctor
+    (gen/vector (gen/such-that
+                  (complement node/printable-only?)
+                  child-generator)
+                min
+                max)))
 
 (def node
   (gen/recursive-gen 

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -57,23 +57,23 @@
 ;;reader-macro-node
 ;;uneval-node
 ;;unquote-node
-;;unquote-splicing-node
 
 (def ^:private containers
-  [;ctor                     min max
-   [#'node/deref-node        1   1]
-   [#'node/eval-node         1   1]
-   [#'node/fn-node           1   5]
-   [#'node/forms-node        0   5]
-   [#'node/list-node         0   5]
-   [#'node/map-node          0   5]
-   [#'node/meta-node         2   2]
-   [#'node/quote-node        1   1]
-   [#'node/raw-meta-node     2   2]
-   [#'node/set-node          0   5]
-   [#'node/syntax-quote-node 1   1]
-   [#'node/var-node          1   1]
-   [#'node/vector-node       0   5]])
+  [;ctor                         min max
+   [#'node/deref-node            1   1]
+   [#'node/eval-node             1   1]
+   [#'node/fn-node               1   5]
+   [#'node/forms-node            0   5]
+   [#'node/list-node             0   5]
+   [#'node/map-node              0   5]
+   [#'node/meta-node             2   2]
+   [#'node/quote-node            1   1]
+   [#'node/raw-meta-node         2   2]
+   [#'node/set-node              0   5]
+   [#'node/syntax-quote-node     1   1]
+   [#'node/unquote-splicing-node 1   1]
+   [#'node/var-node              1   1]
+   [#'node/vector-node           0   5]])
 
 (defn- container*
   [child-generator [ctor min max]]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -73,15 +73,19 @@
 ;;meta-node
 ;;raw-meta-node
 ;;set-node
-;;vector-node
 
 (defn forms-node*
   [child-generator]
   (gen/fmap node/forms-node (gen/vector child-generator)))
 
+(defn vector-node*
+  [child-generator]
+  (gen/fmap node/vector-node (gen/vector child-generator)))
+
 (defn container-node
   [inner-generator]
-  (gen/one-of [(forms-node* inner-generator)]))
+  (gen/one-of [(forms-node* inner-generator)
+               (vector-node* inner-generator)]))
 
 (def node
   (gen/recursive-gen container-node leaf-node))
@@ -89,5 +93,5 @@
 (def children
   (gen/vector node))
 
-(def forms-node
-  (forms-node* children))
+(def forms-node (forms-node* children))
+(def vector-node (vector-node* children))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -74,6 +74,7 @@
    [#'node/map-node    0   5]
    [#'node/quote-node  1   1]
    [#'node/set-node    0   5]
+   [#'node/var-node    1   1]
    [#'node/vector-node 0   5]])
 
 (defn- container*

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -78,6 +78,22 @@
    :var              [1 1 node/var-node              ]
    :vector           [0 5 node/vector-node           ]})
 
+
+(def all-node-types
+  (into #{} (keys node-specs)))
+
+(def leaf-node-types
+  (->> node-specs
+    (filter (comp gen/generator? second))
+    (map first)
+    (into #{})))
+
+(def printable-only-types
+  #{:comment
+    :newline
+    :whitespace
+    :uneval})
+
 (defn- container*
   [child-generator [min max ctor]]
   (gen/fmap
@@ -88,15 +104,6 @@
                   50)
                 min
                 max)))
-
-(def all-node-types
-  (into #{} (keys node-specs)))
-
-(def leaf-node-types
-  (->> node-specs
-    (filter (comp gen/generator? second))
-    (map first)
-    (into #{})))
 
 (defn node
   ([]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -54,21 +54,19 @@
 
 ;; Container nodes
 
-;;deref-node
 ;;eval-node
 ;;fn-node
 ;;meta-node
-;;quote-node
 ;;raw-meta-node
 ;;reader-macro-node
 ;;syntax-quote-node
 ;;uneval-node
 ;;unquote-node
 ;;unquote-splicing-node
-;;var-node
 
 (def ^:private containers
   [;ctor               min max
+   [#'node/deref-node  1   1]
    [#'node/forms-node  0   5]
    [#'node/list-node   0   5]
    [#'node/map-node    0   5]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -70,43 +70,27 @@
 ;;unquote-splicing-node
 ;;var-node
 
-(defn forms-node*
-  [child-generator]
-  (gen/fmap node/forms-node (gen/vector child-generator)))
+(def ^:private containers
+  [node/forms-node
+   node/list-node
+   node/map-node
+   node/set-node
+   node/vector-node])
 
-(defn list-node*
+(defn- container-node*
   [child-generator]
-  (gen/fmap node/list-node (gen/vector child-generator)))
+  (fn [ctor]
+    (gen/fmap ctor (gen/vector child-generator))))
 
-;; TODO: Ensure an even number of non-whitespace nodes
-(defn map-node*
-  [child-generator]
-  (gen/fmap node/map-node (gen/vector child-generator)))
-
-(defn set-node*
-  [child-generator]
-  (gen/fmap node/set-node (gen/vector child-generator)))
-
-(defn vector-node*
-  [child-generator]
-  (gen/fmap node/vector-node (gen/vector child-generator)))
-
-(defn container-node
+(defn- container-node
   [inner-generator]
-  (gen/one-of [(forms-node* inner-generator)
-               (list-node* inner-generator)
-               (map-node* inner-generator)
-               (set-node* inner-generator)
-               (vector-node* inner-generator)]))
+  (gen/one-of
+    (map
+      (container-node* inner-generator)
+      containers)))
 
 (def node
   (gen/recursive-gen container-node leaf-node))
 
 (def children
   (gen/vector node))
-
-(def forms-node (forms-node* node))
-(def list-node (list-node* node))
-(def map-node (map-node* node))
-(def set-node (set-node* node))
-(def vector-node (vector-node* node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -46,11 +46,14 @@
     (comp node/whitespace-node (partial apply str))
     (gen/vector (gen/elements [\, \space \tab]) 1 5)))
 
-(def atom-node
-  (gen/one-of [integer-node
+(def leaf-node
+  (gen/one-of [comment-node
+               integer-node
                keyword-node
+               newline-node
                string-node
-               token-node]))
+               token-node
+               whitespace-node]))
 
 ;; Container nodes
 
@@ -80,7 +83,8 @@
     ctor
     (gen/vector (gen/such-that
                   (complement node/printable-only?)
-                  child-generator)
+                  child-generator
+                  50)
                 min
                 max)))
 
@@ -91,4 +95,4 @@
         (map
           (partial container* inner)
           containers)))
-    atom-node))
+    leaf-node))

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -98,14 +98,23 @@
     :uneval})
 
 (defn- container*
+  "Helper to generate a container type.  Generates from `min` to `max` usable
+  nodes and from 0 to `(inc max)` printable-only nodes, then interleaves them
+  randomly.  The containers constructor, `ctor`, is then applied to the
+  resulting vector of children."
   [child-generator printable-only-generator [min max ctor]]
   (gen/fmap
     ctor
     (gen/fmap
-      first
+      (fn [[children printable-only ordering]]
+        (->> (concat children printable-only)
+          (map vector ordering)
+          (sort-by first)
+          (map second)))
       (gen/tuple
         (gen/vector child-generator min max)
-        (gen/vector printable-only-generator 0 (inc max))))))
+        (gen/vector printable-only-generator 0 (inc max))
+        (gen/vector (gen/choose 0 Long/MAX_VALUE) (+ max (inc max)))))))
 
 (defn node
   ([]

--- a/test/rewrite_clj/node/node_test.clj
+++ b/test/rewrite_clj/node/node_test.clj
@@ -1,0 +1,14 @@
+(ns rewrite-clj.node.node-test
+  (:require [clojure.test.check.properties :as prop]
+            [midje.sweet :refer :all]
+            [rewrite-clj.node :as node]
+            [rewrite-clj.node.generators :as g]
+            [rewrite-clj.test-helpers :refer :all]))
+
+(property "nodes with children report accurate leader lengths"
+  (prop/for-all [node (g/node g/container-node-types)]
+    (let [node-str (node/string node)
+          children-str (apply str (map node/string (node/children node)))
+          leader (node/leader-length node)]
+      (= (subs node-str leader (+ leader (count children-str)))
+         children-str))))

--- a/test/rewrite_clj/regression_test.clj
+++ b/test/rewrite_clj/regression_test.clj
@@ -3,7 +3,7 @@
             [rewrite-clj
              [node :as node]
              [zip :as z]]
-            [clojure.zip :as fz]))
+            [rewrite-clj.zip.zip :as fz]))
 
 ;; ## Regression Tests for 0.3.x -> 0.4.x
 

--- a/test/rewrite_clj/zip/base_test.clj
+++ b/test/rewrite_clj/zip/base_test.clj
@@ -2,7 +2,7 @@
   (:require [midje.sweet :refer :all]
             [rewrite-clj.node :as node]
             [rewrite-clj.zip.base :as base]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 (let [n (node/forms-node
           [(node/spaces 3)

--- a/test/rewrite_clj/zip/find_test.clj
+++ b/test/rewrite_clj/zip/find_test.clj
@@ -1,6 +1,6 @@
 (ns rewrite-clj.zip.find-test
   (:require [midje.sweet :refer :all]
-            [clojure.zip :as z]
+            [rewrite-clj.zip.zip :as z]
             [rewrite-clj.zip
              [base :as base]
              [find :as f]]))

--- a/test/rewrite_clj/zip/insert_test.clj
+++ b/test/rewrite_clj/zip/insert_test.clj
@@ -4,7 +4,7 @@
              [base :as base]
              [move :as m]
              [insert :refer :all]]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 (tabular
   (fact "about whitespace-aware insertion."

--- a/test/rewrite_clj/zip/remove_test.clj
+++ b/test/rewrite_clj/zip/remove_test.clj
@@ -4,7 +4,7 @@
              [base :as base]
              [move :as m]
              [remove :as r]]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 (tabular
   (fact "about whitespace-aware removal."

--- a/test/rewrite_clj/zip/subedit_test.clj
+++ b/test/rewrite_clj/zip/subedit_test.clj
@@ -4,7 +4,7 @@
              [base :as base]
              [move :as m]
              [subedit :refer :all]]
-            [clojure.zip :as z]))
+            [rewrite-clj.zip.zip :as z]))
 
 (let [root (base/of-string "[1 #{2 [3 4] 5} 6]")]
   (fact "about modifying subtrees."

--- a/test/rewrite_clj/zip/utils_test.clj
+++ b/test/rewrite_clj/zip/utils_test.clj
@@ -1,22 +1,28 @@
 (ns rewrite-clj.zip.utils-test
   (:require [midje.sweet :refer :all]
+            [rewrite-clj.node :as node]
+            [rewrite-clj.zip.base :as base]
             [rewrite-clj.zip.zip :as z]
             [rewrite-clj.zip.utils :refer :all]))
 
-(let [loc (z/down (z/vector-zip '[a b c d]))]
+(let [a (node/token-node 'a)
+      b (node/token-node 'b)
+      c (node/token-node 'c)
+      d (node/token-node 'd)
+      loc (z/down (base/edn* (node/forms-node [a b c d])))]
   (fact "about 'remove-right'."
         (let [loc' (remove-right loc)]
-          (z/node loc') => 'a
-          (z/root loc') => '[a c d]))
+          (base/sexpr loc') => 'a
+          (base/root-string loc') => "acd"))
   (fact "about 'remove-left'."
         (let [loc' (-> loc z/right z/right remove-left)]
-          (z/node loc') => 'c
-          (z/root loc') => '[a c d]))
+          (base/sexpr loc') => 'c
+          (base/root-string loc') => "acd"))
   (fact "about 'remove-and-move-right'."
         (let [loc' (remove-and-move-right (z/right loc))]
-          (z/node loc') => 'c
-          (z/root loc') => '[a c d]))
+          (base/sexpr loc') => 'c
+          (base/root-string loc') => "acd"))
   (fact "about 'remove-and-move-left'."
         (let [loc' (-> loc z/right remove-and-move-left)]
-          (z/node loc') => 'a
-          (z/root loc') => '[a c d])))
+          (base/sexpr loc') => 'a
+          (base/root-string loc') => "acd")))

--- a/test/rewrite_clj/zip/utils_test.clj
+++ b/test/rewrite_clj/zip/utils_test.clj
@@ -26,3 +26,13 @@
         (let [loc' (-> loc z/right remove-and-move-left)]
           (base/sexpr loc') => 'a
           (base/root-string loc') => "acd")))
+
+(tabular
+  (fact "`remove-and-move-left` tracks current position correctly"
+    (let [root (base/of-string "[a bb ccc]")
+          zloc (nth (iterate z/next root) ?n)]
+      (z/position (remove-and-move-left zloc)) => ?pos))
+  ?n ?pos
+  3  [1 3]
+  5  [1 6]
+  2  [1 2])

--- a/test/rewrite_clj/zip/utils_test.clj
+++ b/test/rewrite_clj/zip/utils_test.clj
@@ -36,3 +36,13 @@
   3  [1 3]
   5  [1 6]
   2  [1 2])
+
+(tabular
+  (fact "`remove-and-move-right` does not affect position"
+    (let [root (base/of-string "[a bb ccc]")
+          zloc (nth (iterate z/next root) ?n)]
+      (z/position (remove-and-move-right zloc)) => ?pos))
+  ?n ?pos
+  3  [1 4]
+  1  [1 2]
+  2  [1 3])

--- a/test/rewrite_clj/zip/utils_test.clj
+++ b/test/rewrite_clj/zip/utils_test.clj
@@ -1,6 +1,6 @@
 (ns rewrite-clj.zip.utils-test
   (:require [midje.sweet :refer :all]
-            [clojure.zip :as z]
+            [rewrite-clj.zip.zip :as z]
             [rewrite-clj.zip.utils :refer :all]))
 
 (let [loc (z/down (z/vector-zip '[a b c d]))]

--- a/test/rewrite_clj/zip/utils_test.clj
+++ b/test/rewrite_clj/zip/utils_test.clj
@@ -46,3 +46,12 @@
   3  [1 4]
   1  [1 2]
   2  [1 3])
+
+(tabular
+  (fact "`remove-left` tracks current position correctly"
+    (let [root (base/of-string "[a bb ccc]")
+          zloc (nth (iterate z/next root) ?n)]
+      (z/position (remove-left zloc)) => ?pos))
+  ?n ?pos
+  3  [1 3]
+  5  [1 6])

--- a/test/rewrite_clj/zip/whitespace_test.clj
+++ b/test/rewrite_clj/zip/whitespace_test.clj
@@ -1,5 +1,6 @@
 (ns rewrite-clj.zip.whitespace-test
   (:require [midje.sweet :refer :all]
+            [rewrite-clj.zip.base :as base]
             [rewrite-clj.zip.zip :as z]
             [rewrite-clj.node :as node]
             [rewrite-clj.zip.whitespace :refer :all]))
@@ -9,8 +10,7 @@
       c0 (node/comment-node "comment")
       t0 (node/token-node 0)
       t1 (node/token-node 1)
-      loc (z/vector-zip [space linebreak t0 space t1 c0])
-      ->str #(apply str (map node/string %))]
+      loc (base/edn* (node/forms-node [space linebreak t0 space t1 c0]))]
   (fact "about predicates."
         (-> loc z/down)             => whitespace?
         (-> loc z/down z/right)     => linebreak?
@@ -28,12 +28,12 @@
           (node/tag n) => :token
           (node/sexpr n) => 0))
   (fact "about prepending/appending spaces."
-        (let [n (-> loc z/down z/rightmost (prepend-space 3) z/root)]
-          (->str n) => " \n0 1   ;comment")
-        (let [n (-> loc z/down z/rightmost (append-space 3) z/root)]
-          (->str n) => " \n0 1;comment   "))
+        (let [n (-> loc z/down z/rightmost (prepend-space 3))]
+          (base/root-string n) => " \n0 1   ;comment")
+        (let [n (-> loc z/down z/rightmost (append-space 3))]
+          (base/root-string n) => " \n0 1;comment   "))
   (fact "about prepending/appending linebreaks."
-        (let [n (-> loc z/down z/rightmost (prepend-newline 3) z/root)]
-          (->str n) => " \n0 1\n\n\n;comment")
-        (let [n (-> loc z/down z/rightmost (append-newline 3) z/root)]
-          (->str n) => " \n0 1;comment\n\n\n")))
+        (let [n (-> loc z/down z/rightmost (prepend-newline 3))]
+          (base/root-string n) => " \n0 1\n\n\n;comment")
+        (let [n (-> loc z/down z/rightmost (append-newline 3))]
+          (base/root-string n) => " \n0 1;comment\n\n\n")))

--- a/test/rewrite_clj/zip/whitespace_test.clj
+++ b/test/rewrite_clj/zip/whitespace_test.clj
@@ -1,6 +1,6 @@
 (ns rewrite-clj.zip.whitespace-test
   (:require [midje.sweet :refer :all]
-            [clojure.zip :as z]
+            [rewrite-clj.zip.zip :as z]
             [rewrite-clj.node :as node]
             [rewrite-clj.zip.whitespace :refer :all]))
 

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -2,13 +2,15 @@
   (:require [midje.sweet :refer :all]
             [rewrite-clj.node :as node]
             [rewrite-clj.test-helpers :refer :all]
-            [rewrite-clj.zip.zip :as z]))
+            [rewrite-clj.zip
+              [base :as base]
+              [zip :as z]]))
 
 (fact "zipper starts with position [1 1]"
   (z/position (z/zipper (node/comment-node "hello"))) => [1 1])
 
 (tabular
-  (fact "z/down computes position correctly"
+  (fact "z/down tracks position correctly"
     (-> (z/zipper (?type [(node/token-node "hello")]))
       z/down
       z/position) => ?pos)
@@ -16,3 +18,13 @@
   node/forms-node  [1 1]
   node/fn-node     [1 3]
   node/quote-node  [1 2])
+
+(tabular
+  (fact "z/right tracks position correctly"
+    (let [root (base/of-string "[hello world]")
+          zloc (nth (iterate z/right (z/down root)) ?n)]
+      (z/position zloc) => ?pos))
+  ?n ?pos
+  0  [1 2]
+  1  [1 7]
+  2  [1 8])

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -58,3 +58,10 @@
   1  [1 7]
   2  [1 4]
   3  [1 1])
+
+(fact "z/leftmost tracks position correctly"
+  (-> (base/of-string "[hello world]")
+    z/down
+    z/right z/right
+    z/leftmost
+    z/position) => [1 2])

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -76,3 +76,9 @@
     z/down
     (z/replace 'x)
     z/position) => [1 2])
+
+(fact "z/insert-right doesn't change the current position"
+  (-> (base/of-string "[hello world]")
+    z/down
+    (z/insert-right 'x)
+    z/position) => [1 2])

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -28,3 +28,7 @@
   0  [1 2]
   1  [1 7]
   2  [1 8])
+
+(fact "z/rightmost tracks position correctly"
+  (let [root (base/of-string "[hello world]")]
+    (-> root z/down z/rightmost z/position) => [1 8]))

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -32,3 +32,13 @@
 (fact "z/rightmost tracks position correctly"
   (let [root (base/of-string "[hello world]")]
     (-> root z/down z/rightmost z/position) => [1 8]))
+
+(tabular
+  (fact "z/left tracks position correctly"
+    (let [root (base/of-string "[hello world]")
+          zloc (nth (iterate z/left (z/rightmost (z/down root))) ?n)]
+      (z/position zloc) => ?pos))
+  ?n ?pos
+  0 [1 8]
+  1 [1 7]
+  2 [1 2])

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -82,3 +82,10 @@
     z/down
     (z/insert-right 'x)
     z/position) => [1 2])
+
+(fact "z/insert-left fixes the position"
+  (-> (base/of-string "[hello world]")
+    z/down
+    z/right
+    (z/insert-left 'x)
+    z/position) => [1 8])

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -83,9 +83,11 @@
     (z/insert-right 'x)
     z/position) => [1 2])
 
-(fact "z/insert-left fixes the position"
-  (-> (base/of-string "[hello world]")
-    z/down
-    z/right
-    (z/insert-left 'x)
-    z/position) => [1 8])
+(tabular
+  (fact "z/insert-left fixes the position"
+    (let [root (base/of-string "[hello world]")
+          zloc (nth (iterate z/right (z/down root)) ?n)]
+      (z/position (z/insert-left zloc 'x)) => ?pos))
+  ?n ?pos
+  0 [1 3]
+  1 [1 8])

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -6,3 +6,13 @@
 
 (fact "zipper starts with position [1 1]"
   (z/position (z/zipper (node/comment-node "hello"))) => [1 1])
+
+(tabular
+  (fact "z/down computes position correctly"
+    (-> (z/zipper (?type [(node/token-node "hello")]))
+      z/down
+      z/position) => ?pos)
+  ?type            ?pos
+  node/forms-node  [1 1]
+  node/fn-node     [1 3]
+  node/quote-node  [1 2])

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -70,3 +70,9 @@
   (let [root (base/of-string "[hello world]")]
     (-> root z/down z/remove z/position) => [1 1]
     (-> root z/down z/right z/remove z/position) => [1 2]))
+
+(fact "z/replace doesn't change the current position"
+  (-> (base/of-string "[hello world]")
+    z/down
+    (z/replace 'x)
+    z/position) => [1 2])

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -1,0 +1,8 @@
+(ns rewrite-clj.zip.zip-test
+  (:require [midje.sweet :refer :all]
+            [rewrite-clj.node :as node]
+            [rewrite-clj.test-helpers :refer :all]
+            [rewrite-clj.zip.zip :as z]))
+
+(fact "zipper starts with position [1 1]"
+  (z/position (z/zipper (node/comment-node "hello"))) => [1 1])

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -42,3 +42,19 @@
   0 [1 8]
   1 [1 7]
   2 [1 2])
+
+(tabular
+  (fact "z/up tracks position correctly"
+    (let [bottom (-> (base/of-string "[x [y [1]]]")
+                   z/down
+                   z/right z/right
+                   z/down
+                   z/right z/right
+                   z/down)
+          zloc (nth (iterate z/up bottom) ?n)]
+      (z/position zloc) => ?pos))
+  ?n ?pos
+  0  [1 8]
+  1  [1 7]
+  2  [1 4]
+  3  [1 1])

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -21,13 +21,14 @@
 
 (tabular
   (fact "z/right tracks position correctly"
-    (let [root (base/of-string "[hello world]")
-          zloc (nth (iterate z/right (z/down root)) ?n)]
+    (let [root (base/of-string "[hello \nworld]")
+          zloc (nth (iterate z/next root) ?n)]
       (z/position zloc) => ?pos))
   ?n ?pos
-  0  [1 2]
-  1  [1 7]
-  2  [1 8])
+  1  [1 2]
+  2  [1 7]
+  3  [1 8]
+  4  [2 1])
 
 (fact "z/rightmost tracks position correctly"
   (let [root (base/of-string "[hello world]")]

--- a/test/rewrite_clj/zip/zip_test.clj
+++ b/test/rewrite_clj/zip/zip_test.clj
@@ -65,3 +65,8 @@
     z/right z/right
     z/leftmost
     z/position) => [1 2])
+
+(fact "z/remove tracks position correctly"
+  (let [root (base/of-string "[hello world]")]
+    (-> root z/down z/remove z/position) => [1 1]
+    (-> root z/down z/right z/remove z/position) => [1 2]))


### PR DESCRIPTION
**whew!!**  This was a lot of work!

This introduces a function `zip/position` which returns `[row col]` for the current zipper location.  It is *always* up-to-date, even with insertions and removals (see the test.check property).

I copied Rich's `clojure.zip` into this project, simplified it (it was using a weirdly unnecessary two-level data structure which is now just a map), then added position tracking to it.  I kept Rich's copyright notice.

It will use node metadata if it is available to calculate the node's "extent" (but not the position) though it doesn't update the metadata.  We lose it when we change the node anyhow.

This PR contains the previous PR with the full suite of node generators.