### PR TITLE
Create a comma node and add parser support

### DIFF
--- a/src/rewrite_clj/node.clj
+++ b/src/rewrite_clj/node.clj
@@ -92,7 +92,10 @@
    newline-node
    spaces
    whitespace-node
-   whitespace?])
+   whitespace?
+   comma-node
+   comma?
+   whitespace-nodes])
 
 ;; ## Predicates
 

--- a/src/rewrite_clj/node/coerce.clj
+++ b/src/rewrite_clj/node/coerce.clj
@@ -73,14 +73,14 @@
 
 ;; ## Maps
 
-(let [comma (ws/whitespace-node ", ")
+(let [comma (ws/whitespace-nodes ", ")
       space (ws/whitespace-node " ")]
   (defn- map->children
     [m]
     (->> (mapcat
-           (fn [[k v]]
-             [(coerce k) space (coerce v) comma])
-           m)
+          (fn [[k v]]
+            [(coerce k) space (coerce v) comma])
+          m)
          (butlast)
          (vec))))
 

--- a/src/rewrite_clj/node/coerce.clj
+++ b/src/rewrite_clj/node/coerce.clj
@@ -79,9 +79,9 @@
     [m]
     (->> (mapcat
           (fn [[k v]]
-            [(coerce k) space (coerce v) comma])
+            (list* (coerce k) space (coerce v) comma))
           m)
-         (butlast)
+         (drop-last (count comma))
          (vec))))
 
 (defn- record-node

--- a/src/rewrite_clj/node/whitespace.clj
+++ b/src/rewrite_clj/node/whitespace.clj
@@ -72,7 +72,7 @@
   [s]
   {:pre [(string? s)
          (re-matches #"\s+" s)
-         (not (re-matches #".*[\n\r,].*" s))]}
+         (not (re-matches #".*[\n\r].*" s))]}
   (->WhitespaceNode s))
 
 (defn comma-node

--- a/src/rewrite_clj/node/whitespace.clj
+++ b/src/rewrite_clj/node/whitespace.clj
@@ -129,7 +129,9 @@
   (defn comma-separated
     "Interleave the given seq of nodes with `\", \"` nodes."
     [nodes]
-    (butlast (interleave nodes (repeat comma)))))
+    (->> nodes
+         (mapcat #(cons % comma))
+         (drop-last (count comma)))))
 
 (let [nl (newline-node "\n")]
   (defn line-separated

--- a/src/rewrite_clj/node/whitespace.clj
+++ b/src/rewrite_clj/node/whitespace.clj
@@ -79,8 +79,7 @@
   "Create comma node."
   [s]
   {:pre [(string? s)
-         (re-matches #",+" s)
-         (not (re-matches #".*[\n\r\s].*" s))]}
+         (re-matches #",+" s)]}
   (->CommaNode s))
 
 (defn newline-node

--- a/src/rewrite_clj/parser/whitespace.clj
+++ b/src/rewrite_clj/parser/whitespace.clj
@@ -9,6 +9,6 @@
   [reader]
   (if (reader/linebreak? (reader/peek reader))
     (node/newline-node
-      (reader/read-while reader reader/linebreak?))
-    (node/whitespace-node
-      (reader/read-while reader reader/space?))))
+     (reader/read-while reader reader/linebreak?))
+    (node/whitespace-nodes
+     (reader/read-while reader reader/space?))))

--- a/src/rewrite_clj/parser/whitespace.clj
+++ b/src/rewrite_clj/parser/whitespace.clj
@@ -7,8 +7,15 @@
   "Parse as much whitespace as possible. The created node can either contain
    only linebreaks or only space/tabs."
   [reader]
-  (if (reader/linebreak? (reader/peek reader))
-    (node/newline-node
-     (reader/read-while reader reader/linebreak?))
-    (node/whitespace-nodes
-     (reader/read-while reader reader/space?))))
+  (let [c (reader/peek reader)]
+    (cond (reader/linebreak? c)
+          (node/newline-node
+            (reader/read-while reader reader/linebreak?))
+
+          (reader/comma? c)
+          (node/comma-node
+            (reader/read-while reader reader/comma?))
+
+          :else
+          (node/whitespace-node
+            (reader/read-while reader reader/space?)))))

--- a/src/rewrite_clj/reader.clj
+++ b/src/rewrite_clj/reader.clj
@@ -28,11 +28,15 @@
       \( \) \[ \] \{ \} \\ nil}
     c))
 
+(defn comma?
+  [^java.lang.Character c]
+  (= c \,))
+
 (defn whitespace?
   [^java.lang.Character c]
   (and c
-       (or (Character/isWhitespace c)
-           (= c \,))))
+       (or (comma? c)
+           (Character/isWhitespace c))))
 
 (defn linebreak?
   [^java.lang.Character c]

--- a/test/rewrite_clj/node/generators.clj
+++ b/test/rewrite_clj/node/generators.clj
@@ -45,7 +45,12 @@
 (def whitespace-node
   (gen/fmap
     (comp node/whitespace-node (partial apply str))
-    (gen/vector (gen/elements [\, \space \tab]) 1 5)))
+    (gen/vector (gen/elements [\space \tab]) 1 5)))
+
+(def comma-node
+  (gen/fmap
+    (comp node/comma-node (partial apply str))
+    (gen/vector (gen/return \,) 1 5)))
 
 ;; Container nodes
 
@@ -58,6 +63,7 @@
    :string           string-node
    :token            token-node
    :whitespace       whitespace-node
+   :comma            comma-node
 
    ;containers        < > ctor
    :deref            [1 1 node/deref-node            ]
@@ -95,6 +101,7 @@
   #{:comment
     :newline
     :whitespace
+    :comma
     :uneval})
 
 (defn- container*


### PR DESCRIPTION
This is more of a RFC than a finished PR, as this badly breaks the test suite and requires a change to the programming interface.

While "," is lexical whitespace in Clojure, it doesn't make sense from the perspective of indentation or rewriting tools to treat it as such. In the case of trailing commas it works ... okay. Because "," is treated as whitespace tools like cljfmt which remove trailing "whitespace" will tend to rewrite comma paired maps. From the indenter's perspective there really isn't a good logical way around this, as preserving trailing commas requires introspecting and rewriting trailing whitespace to minimize it, rather than simply understanding that `#",+"` is significant whitespace which should not simply be discarded.

I consider the two following cases to be "correct" understandings of "," usage.

#### Ex 1.
```clojure
{:foo :bar,
 :baz :qux}
```

#### Ex 2.
```clojure
(cond
  (a-pred? ...)
  ,,(a-fn ...))
```

Neither of which is enabled by the present strict understanding of "," as whitespace.

This PR has the following impact:

- Creates a node representing one or more commas
- Refactors whitespace-node to strictly represent `#"\s+"`
- Refactors whitespace-nodes to parse comma nodes as well
- Simplifies some parser logic by reusing predicates from the reader
- Extends the `whitespace?` predicate so that comma nodes are treated as whitespace
- Exposes whitespace-nodes as part of the API
- Refactors existing code to make use of whitespace-nodes instead of whitespace-node where appropriate

Because of the last refactor, this is technically a breaking change. I personally don't think it makes sense to overload the existing whitespace-node constructor to potentially generate several nodes rather than one, but the consequence is that consumers are now expected to make use of whitespace-nodes in order to achieve the same semantics :disappointed: 

However this enables tooling to opt into treating "," specially using the `comma?` predicate while preserving existing behavior derived from the `whitespace?` predicate.