### PR TITLE
Implement reader support for #?@

### DIFF
--- a/src/rewrite_clj/reader.clj
+++ b/src/rewrite_clj/reader.clj
@@ -109,6 +109,11 @@
   [reader]
   (r/read-char reader))
 
+(defn unread
+  "Unreads a char. Puts the char back on the reader."
+  [reader ch]
+  (r/unread reader ch))
+
 (defn peek
   "Peek next char."
   [reader]

--- a/test/rewrite_clj/parser_test.clj
+++ b/test/rewrite_clj/parser_test.clj
@@ -86,7 +86,7 @@
   "#=sym"                :eval             []              '(eval 'sym)
   "#=  sym"              :eval             [:whitespace]   '(eval 'sym)
   "#'sym"                :var              []              '(var sym)
-  "#'\nsym"              :var              [:newline])     '(var sym)
+  "#'\nsym"              :var              [:newline])
 
 (fact "about eval."
       (let [n (p/parse-string "#=(+ 1 2)")]
@@ -189,6 +189,9 @@
   "#=(+ 1 2)"                :eval            [:list]
   "#macro 1"                 :reader-macro    [:token :whitespace :token]
   "#macro (* 2 3)"           :reader-macro    [:token :whitespace :list]
+  "#?(:clj bar)"             :reader-macro    [:token :list]
+  "#?@(:clj bar)"            :reader-macro    [:token :list]
+  "#?foo baz"                :reader-macro    [:token :whitespace :token]
   "#_abc"                    :uneval          [:token]
   "#_(+ 1 2)"                :uneval          [:list]
   "#(+ % 1)"                 :fn              [:token :whitespace


### PR DESCRIPTION
This changeset adds "sharp" reader support for the #?@ unquote reader
macro, added in Clojure 1.7.0. Unfortunately the parser is somewhat
complicated because there are three #? cases:

1. #? ...
2. #?@ ...
3. #?foo ...

The first case was already correctly handled. The second case requires
extending the parser to recognize \?\@, which requires consuming an
additional character from the reader before delegating to reading
subsequent form. Unfortunately to handle the third case correctly, we
need to push the \? back onto the reader, before simply reading a pair
of tokens.

Fixes xsc/rewrite-clj#46