### PR TITLE
Use a separate node type for regex forms

### DIFF
--- a/src/rewrite_clj/node.clj
+++ b/src/rewrite_clj/node.clj
@@ -12,6 +12,7 @@
              protocols
              quote
              reader-macro
+             regex
              seq
              string
              token
@@ -56,6 +57,9 @@
   [rewrite-clj.node.meta
    meta-node
    raw-meta-node]
+
+  [rewrite-clj.node.regex
+   regex-node]
 
   [rewrite-clj.node.reader-macro
    deref-node

--- a/src/rewrite_clj/node/regex.clj
+++ b/src/rewrite_clj/node/regex.clj
@@ -1,0 +1,22 @@
+(ns ^:no-doc rewrite-clj.node.regex
+  (:require [rewrite-clj.node.protocols :as node]))
+
+
+;; ## Node
+
+(defrecord RegexNode [pattern]
+  rewrite-clj.node.protocols/Node
+  (tag [_] :regex)
+  (printable-only? [_] false)
+  (sexpr [_] (list 're-pattern pattern))
+  (length [_] 1)
+  (string [_] (str "#\"" pattern "\"")))
+
+(node/make-printable! RegexNode)
+
+;; ## Constructor
+
+(defn regex-node
+  "Create node representing a regex"
+  [pattern-string]
+  (->RegexNode pattern-string))

--- a/src/rewrite_clj/parser/core.clj
+++ b/src/rewrite_clj/parser/core.clj
@@ -114,7 +114,7 @@
     nil (reader/throw-reader reader "Unexpected EOF.")
     \{ (node/set-node (parse-delim reader \}))
     \( (node/fn-node (parse-delim reader \)))
-    \" (parse-regex reader)
+    \" (node/regex-node (parse-regex reader))
     \^ (node/raw-meta-node (parse-printables reader :meta 2 true))
     \' (node/var-node (parse-printables reader :var 1 true))
     \= (node/eval-node (parse-printables reader :eval 1 true))

--- a/src/rewrite_clj/parser/string.clj
+++ b/src/rewrite_clj/parser/string.clj
@@ -40,4 +40,4 @@
 (defn parse-regex
   [reader]
   (let [h (read-string-data reader)]
-    (node/token-node (re-pattern (string/join "\n" h)))))
+    (string/join "\n" h)))

--- a/test/rewrite_clj/parser_test.clj
+++ b/test/rewrite_clj/parser_test.clj
@@ -112,15 +112,15 @@
 (tabular
   (fact "about parsing regular expressions"
     (let [n (p/parse-string ?s)]
-      (node/tag n) => :token
-      (class (node/sexpr n)) => java.util.regex.Pattern
-      (str (node/sexpr n)) => ?p))
+      (node/tag n) => :regex
+      (node/sexpr n) => ?p))
   ?s                 ?p
-  "#\"regex\""       "regex"
-  "#\"regex\\.\""    "regex\\."
-  "#\"[reg|k].x\""   "[reg|k].x"
-  "#\"a\\nb\""       "a\\nb"
-  "#\"a\nb\""        "a\nb")
+
+  "#\"regex\""       '(re-pattern "regex")
+  "#\"regex\\.\""    '(re-pattern "regex\\.")
+  "#\"[reg|k].x\""   '(re-pattern "[reg|k].x")
+  "#\"a\\nb\""       '(re-pattern "a\\nb")
+  "#\"a\nb\""        '(re-pattern "a\nb"))
 
 (tabular
   (fact "about parsing strings"


### PR DESCRIPTION
This node type stores the pattern string, instead of using generic token nodes
that store java.util.Pattern objects.
This new node type lets `node/sexpr` return the expanded `(re-pattern "pattern-string")` form instead of a `java.util.Pattern` object.

java.util.Pattern instances cannot be compared using equals,
which would prevent comparison of sexprs generated by node/sexpr
that contain regex forms

By returning the expanded `re-pattern` form meaningful comparisons can be made
