### PR TITLE
Define form and add a missing bracket in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ handling simple tokens and generates a custom node type representing EDN forms:
 ```clojure
 (require '[rewrite-clj.parser :as p])
 
-(p/parse-string "(defn my-function [a]\n  (* a 3))"
+(def form (p/parse-string "(defn my-function [a]\n  (* a 3))"))
 ;; => <list:
 ;;      (defn my-function [a]
 ;;        (* a 3))


### PR DESCRIPTION
Following the documentation step by step wasn't working now, since form was not defined and there was a syntax error in the line doing the parsing.