### PR TITLE
Provide buffer size to tools.reader/indexing-push-back-reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: clojure
-lein: lein2
-before_script:
-  - lein2 all deps
-script: lein2 all midje
+script: lein all midje
 jdk:
   - openjdk7
   - oraclejdk7
+  - openjdk8
   - oraclejdk8

--- a/src/rewrite_clj/reader.clj
+++ b/src/rewrite_clj/reader.clj
@@ -178,4 +178,4 @@
   (-> (io/file f)
       (io/reader)
       (PushbackReader. 2)
-      (r/indexing-push-back-reader)))
+      (r/indexing-push-back-reader 2)))


### PR DESCRIPTION
This is necessary on newer versions of c.t.r to prevent "Pushback buffer
overflow"

Fixes #60