### PR TITLE
Improve partial support for namespaced maps

### DIFF
--- a/src/rewrite_clj/node.clj
+++ b/src/rewrite_clj/node.clj
@@ -70,6 +70,7 @@
   [rewrite-clj.node.seq
    list-node
    map-node
+   namespaced-map-node
    set-node
    vector-node]
 

--- a/src/rewrite_clj/parser/core.clj
+++ b/src/rewrite_clj/parser/core.clj
@@ -6,7 +6,8 @@
              [keyword :refer [parse-keyword]]
              [string :refer [parse-string parse-regex]]
              [token :refer [parse-token]]
-             [whitespace :refer [parse-whitespace]]]))
+             [whitespace :refer [parse-whitespace]]]
+            [clojure.tools.reader.reader-types :as r]))
 
 ;; ## Base Parser
 
@@ -119,6 +120,9 @@
     \' (node/var-node (parse-printables reader :var 1 true))
     \= (node/eval-node (parse-printables reader :eval 1 true))
     \_ (node/uneval-node (parse-printables reader :uneval 1 true))
+    \: (do
+         (r/unread reader \:)
+         (node/namespaced-map-node (parse-printables reader :keyword 2 true)))
     \? (do
          ;; we need to examine the next character, so consume one (known \?)
          (reader/next reader)

--- a/src/rewrite_clj/parser/core.clj
+++ b/src/rewrite_clj/parser/core.clj
@@ -120,9 +120,7 @@
     \' (node/var-node (parse-printables reader :var 1 true))
     \= (node/eval-node (parse-printables reader :eval 1 true))
     \_ (node/uneval-node (parse-printables reader :uneval 1 true))
-    \: (do
-         (r/unread reader \:)
-         (node/namespaced-map-node (parse-printables reader :keyword 2 true)))
+    \: (node/namespaced-map-node (parse-printables reader :keyword 2))
     \? (do
          ;; we need to examine the next character, so consume one (known \?)
          (reader/next reader)

--- a/test/rewrite_clj/parser_test.clj
+++ b/test/rewrite_clj/parser_test.clj
@@ -243,11 +243,12 @@
 
 (deftest t-parsing-namespaced-maps-with-namespace-alias
   (are [?s]
-       (let [n (p/parse-string ?s)]
-         (is (= :namespaced-map (node/tag n)))
-         (is (= (count ?s) (node/length n)))
-         (is (= ?s (node/string n)))
-         (is (= {::node/x 1, ::node/y 1} (node/sexpr n))))
+       (binding [*ns* (find-ns 'rewrite-clj.parser-test)]
+         (let [n (p/parse-string ?s)]
+           (is (= :namespaced-map (node/tag n)))
+           (is (= (count ?s) (node/length n)))
+           (is (= ?s (node/string n)))
+           (is (= {::node/x 1, ::node/y 1} (node/sexpr n)))))
     "#::node{:x 1, :y 1}"
     "#::node   {:x 1, :y 1}"))
 

--- a/test/rewrite_clj/parser_test.clj
+++ b/test/rewrite_clj/parser_test.clj
@@ -231,6 +231,16 @@
     ";\n"
     ";;\n"))
 
+(deftest t-parsing-namespaced-maps
+  (are [?s]
+       (let [n (p/parse-string ?s)]
+         (is (= :namespaced-map (node/tag n)))
+         (is (= (count ?s) (node/length n)))
+         (is (= ?s (node/string n)))
+         (is (= {:abc/x 1, :abc/y 1} (node/sexpr n))))
+     "#:abc{:x 1, :y 1}"
+     "#:abc   {:x 1, :y 1}"))
+
 (deftest t-parsing-exceptions
   (are [?s ?p]
        (is (thrown? Exception ?p (p/parse-string ?s)))

--- a/test/rewrite_clj/parser_test.clj
+++ b/test/rewrite_clj/parser_test.clj
@@ -241,6 +241,16 @@
      "#:abc{:x 1, :y 1}"
      "#:abc   {:x 1, :y 1}"))
 
+(deftest t-parsing-namespaced-maps-with-namespace-alias
+  (are [?s]
+       (let [n (p/parse-string ?s)]
+         (is (= :namespaced-map (node/tag n)))
+         (is (= (count ?s) (node/length n)))
+         (is (= ?s (node/string n)))
+         (is (= {::node/x 1, ::node/y 1} (node/sexpr n))))
+    "#::node{:x 1, :y 1}"
+    "#::node   {:x 1, :y 1}"))
+
 (deftest t-parsing-exceptions
   (are [?s ?p]
        (is (thrown? Exception ?p (p/parse-string ?s)))


### PR DESCRIPTION
Based on #56, adding support for keyword-namespaced maps (`#:x{:y 1}`) and alias-namespaced maps (`#::x{:y 1}`).

Still missing is support for self-namespaced maps (`#::{:y 1}`).