### PR TITLE
Add support for auto-resolve namespaced maps

### DIFF
--- a/src/rewrite_clj/node.clj
+++ b/src/rewrite_clj/node.clj
@@ -9,6 +9,7 @@
              integer
              keyword
              meta
+             namespaced-map
              protocols
              quote
              reader-macro
@@ -58,6 +59,9 @@
    meta-node
    raw-meta-node]
 
+  [rewrite-clj.node.namespaced-map
+   namespaced-map-node]
+
   [rewrite-clj.node.regex
    regex-node]
 
@@ -70,7 +74,6 @@
   [rewrite-clj.node.seq
    list-node
    map-node
-   namespaced-map-node
    set-node
    vector-node]
 

--- a/src/rewrite_clj/node/namespaced_map.clj
+++ b/src/rewrite_clj/node/namespaced_map.clj
@@ -1,6 +1,5 @@
 (ns ^:no-doc rewrite-clj.node.namespaced-map
   (:require
-   [clojure.string :as str]
    [rewrite-clj.node.protocols :as node]))
 
 ;; ## Node

--- a/src/rewrite_clj/node/namespaced_map.clj
+++ b/src/rewrite_clj/node/namespaced_map.clj
@@ -1,0 +1,76 @@
+(ns ^:no-doc rewrite-clj.node.namespaced-map
+  (:require
+   [clojure.string :as str]
+   [rewrite-clj.node.protocols :as node]))
+
+;; ## Node
+
+(defn- assert-namespaced-map-children
+  [children]
+  (let [exs (node/sexprs children)]
+    (assert (= (count exs) 2)
+            "must contain 2 non-whitespace forms.")
+    (assert (keyword? (first exs))
+            "first form in namespaced must be a keyword.")
+    (assert (map? (second exs))
+            "second form in namespaced map must be a map.")))
+
+(defrecord NamespacedMapNode [children]
+  node/Node
+  (tag [this]
+    :namespaced-map)
+  (printable-only? [_] false)
+  (sexpr [this]
+    (let [[nspace-keyword m] (node/sexprs children)
+          nspace (str nspace-keyword)
+          resolved-nspace (if (= "::" nspace)
+                            (str (ns-name *ns*))
+                            (if (.startsWith nspace "::")
+                              (some-> (ns-aliases *ns*)
+                                      (get (symbol (subs nspace 2)))
+                                      (ns-name)
+                                      str)
+                              (subs nspace 1)))]
+      (assert resolved-nspace
+              (str ":namespaced-map could not resolve namespace " nspace-keyword))
+      (->> (for [[k v] m
+                 :let [k' (cond (not (keyword? k))     k
+                                (= (namespace k) "_")  (keyword (name k))
+                                (namespace k)          k
+                                :else (keyword resolved-nspace (name k)))]]
+             [k' v])
+          (into {}))))
+  (length [_]
+    (+ 1 (node/sum-lengths children)))
+  (string [this]
+    (str "#" (node/concat-strings children)))
+
+  node/InnerNode
+  (inner? [_] true)
+  (children [_]
+    children)
+  (replace-children [this children']
+    (assert-namespaced-map-children children')
+    (assoc this :children children'))
+  (leader-length [_]
+    1)
+
+  Object
+  (toString [this]node/string this))
+
+(node/make-printable! NamespacedMapNode)
+
+;; ## Constructors
+
+(defn namespaced-map-node
+  "Create a node representing a namespaced map.
+
+  `#:prefix{a: 1}`  prefix namespaced map
+  `#::{a: 1}`       auto-resolve namespaced map
+  `#::alias{a: 1}`  auto-resolve alias namespaced map
+
+  First arg is delivered as token node with keyword, second arg is map node.
+  When first arg is :: keyword can be contrived via (keyword \":\")"
+  [children]
+  (assert-namespaced-map-children children)
+  (->NamespacedMapNode children))

--- a/src/rewrite_clj/node/namespaced_map.clj
+++ b/src/rewrite_clj/node/namespaced_map.clj
@@ -10,7 +10,7 @@
     (assert (= (count exs) 2)
             "must contain 2 non-whitespace forms.")
     (assert (keyword? (first exs))
-            "first form in namespaced must be a keyword.")
+            "first form in namespaced map must be a keyword.")
     (assert (map? (second exs))
             "second form in namespaced map must be a map.")))
 

--- a/src/rewrite_clj/parser/core.clj
+++ b/src/rewrite_clj/parser/core.clj
@@ -6,6 +6,7 @@
              [keyword :refer [parse-keyword]]
              [string :refer [parse-string parse-regex]]
              [token :refer [parse-token]]
+             [namespaced-map :refer [parse-namespaced-map]]
              [whitespace :refer [parse-whitespace]]]
             [clojure.tools.reader.reader-types :as r]))
 
@@ -120,7 +121,7 @@
     \' (node/var-node (parse-printables reader :var 1 true))
     \= (node/eval-node (parse-printables reader :eval 1 true))
     \_ (node/uneval-node (parse-printables reader :uneval 1 true))
-    \: (node/namespaced-map-node (parse-printables reader :keyword 2))
+    \: (parse-namespaced-map reader parse-next)
     \? (do
          ;; we need to examine the next character, so consume one (known \?)
          (reader/next reader)

--- a/src/rewrite_clj/parser/namespaced_map.clj
+++ b/src/rewrite_clj/parser/namespaced_map.clj
@@ -1,0 +1,73 @@
+(ns ^:no-doc rewrite-clj.parser.namespaced-map
+  (:require [rewrite-clj
+             [node :as node]
+             [reader :as reader]]
+            [rewrite-clj.parser.utils :as u]))
+
+(defn- parse-nspaced-map-type
+  [reader]
+  (case (reader/peek reader)
+    nil (u/throw-reader reader "Unexpected EOF.")
+    \:  (do (reader/ignore reader) "::")
+    ":"))
+
+(defn- nspace?
+  [reader]
+  (let [c (reader/peek reader)]
+    (and (not (reader/whitespace? c))
+         (not (= \{ c)))))
+
+(defn- keywordize-nspace [type nspace]
+  (node/token-node
+   (if (= "::" type)
+     (keyword (str ":" (node/string nspace)))
+     (keyword (node/string nspace)))))
+
+(defn- parse-nspace
+  [reader fn-parse-next type]
+  (let [n (fn-parse-next reader)]
+    (cond
+      (nil? n)
+      (u/throw-reader reader "Unexpected EOF.")
+
+      (not= :token (node/tag n))
+      (if (= "::" type)
+        (u/throw-reader reader ":namespaced-map expected namespace alias or map")
+        (u/throw-reader reader ":namespaced-map expected namespace prefix"))
+      :else (keywordize-nspace type n))))
+
+(defn- parse-for-printable
+  [reader fn-parse-next]
+  (loop [vs []]
+    (if (and
+         (seq vs)
+         (not (node/printable-only? (last vs))))
+      vs
+      (if-let [v (fn-parse-next reader)]
+        (recur (conj vs v))
+        nil))))
+
+(defn- parse-for-map
+  [reader fn-parse-next]
+  (let [m (parse-for-printable reader fn-parse-next)]
+    (cond
+      (nil? m)
+      (u/throw-reader reader "Unexpected EOF.")
+
+      (not= :map (node/tag (last m)))
+      (u/throw-reader reader ":namespaced-map expects a map")
+      :else m)))
+
+(defn parse-namespaced-map
+  [reader fn-parse-next]
+  (reader/ignore reader)
+  (let [type (parse-nspaced-map-type reader)]
+    (if (nspace? reader)
+      (node/namespaced-map-node
+       (into [(parse-nspace reader fn-parse-next type)]
+             (parse-for-map reader fn-parse-next)))
+      (if (= "::" type)
+        (node/namespaced-map-node
+         (into [(node/token-node (keyword ":"))]
+               (parse-for-map reader fn-parse-next)))
+        (u/throw-reader reader ":namespaced-map expected namespace prefix")))))

--- a/test/rewrite_clj/parser_test.clj
+++ b/test/rewrite_clj/parser_test.clj
@@ -249,7 +249,15 @@
 
     "#:foo{:kw 1, :n/kw 2, :_/bare 3, 0 4}"
     "[<token: :foo> <map: {:kw 1, :n/kw 2, :_/bare 3, 0 4}>]"
-    {:foo/kw 1, :n/kw 2, :bare 3, 0 4}))
+    {:foo/kw 1, :n/kw 2, :bare 3, 0 4}
+
+    "#:abc{:a {:b 1}}"
+    "[<token: :abc> <map: {:a {:b 1}}>]"
+    {:abc/a {:b 1}}
+
+    "#:abc{:a #:def{:b 1}}"
+    "[<token: :abc> <map: {:a #:def{:b 1}}>]"
+    {:abc/a {:def/b 1}}))
 
 (deftest t-parsing-auto-resolve-namespaced-maps
   (are [?s ?children ?sexpr]
@@ -270,7 +278,15 @@
 
     "#::{:kw 1, :n/kw 2, :_/bare 3, 0 4}"
     "[<token: ::> <map: {:kw 1, :n/kw 2, :_/bare 3, 0 4}>]"
-    {:rewrite-clj.parser-test/kw 1, :n/kw 2, :bare 3, 0 4}))
+    {:rewrite-clj.parser-test/kw 1, :n/kw 2, :bare 3, 0 4}
+
+    "#::{:a {:b 1}}"
+    "[<token: ::> <map: {:a {:b 1}}>]"
+    {:rewrite-clj.parser-test/a {:b 1}}
+
+    "#::{:a #::{:b 1}}"
+    "[<token: ::> <map: {:a #::{:b 1}}>]"
+    {:rewrite-clj.parser-test/a {:rewrite-clj.parser-test/b 1}}))
 
 (deftest t-parsing-auto-resolve-alias-namespaced-maps
   (are [?s ?children ?sexpr]
@@ -291,7 +307,15 @@
 
     "#::node{:kw 1, :n/kw 2, :_/bare 3, 0 4}"
     "[<token: ::node> <map: {:kw 1, :n/kw 2, :_/bare 3, 0 4}>]"
-    {:rewrite-clj.node/kw 1, :n/kw 2, :bare 3, 0 4}))
+    {:rewrite-clj.node/kw 1, :n/kw 2, :bare 3, 0 4}
+
+    "#::node{:a {:b 1}}"
+    "[<token: ::node> <map: {:a {:b 1}}>]"
+    {:rewrite-clj.node/a {:b 1}}
+
+    "#::node{:a #::node{:b 1}}"
+    "[<token: ::node> <map: {:a #::node{:b 1}}>]"
+    {:rewrite-clj.node/a {:rewrite-clj.node/b 1}}))
 
 (deftest t-parsing-exceptions
   (are [?s ?p]


### PR DESCRIPTION
Syntax `::{:x 1}` is now supported.
Pre-existing behavior of prefix namespaced maps `:prefix{:x 1}` and
auto-resolve alias namespaced maps `::alias{:x 1}` is preserved.

Also addressed: `t-parsing-exceptions` was not detecting failures.

Fixes #54.